### PR TITLE
build: add `make setup` to enable the local pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,15 @@ endef
 
 .DEFAULT_GOAL := help
 
-.PHONY: help build test coverage check run run-inmemory jar clean docker-build docker-run
+.PHONY: help setup build test coverage check run run-inmemory jar clean docker-build docker-run
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) \
 		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+setup: ## One-time: enable the local Spotless pre-commit hook
+	@git config core.hooksPath .githooks
+	@printf '\033[1;32m▶\033[0m git hooks enabled: \033[36mcore.hooksPath=.githooks\033[0m (pre-commit runs spotlessCheck)\n'
 
 build: ## Compile and assemble all modules (no tests)
 	$(GRADLE) build -x test

--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ The repository implementation is selected by the `btm.persistence` property:
 Code style (ktlint via Spotless) is enforced in the CI pipeline rather than the
 local build. CI fails on any formatting violation, so format before pushing.
 
+To catch violations before they reach CI, enable the bundled pre-commit hook
+once per clone:
+
+```shell
+make setup
+```
+
+This sets `core.hooksPath` to `.githooks`, whose `pre-commit` runs the same
+Spotless check CI runs (via `gradle/spotless.init.gradle.kts`) and blocks the
+commit on violations. Auto-fix them with:
+
+```shell
+./gradlew --init-script gradle/spotless.init.gradle.kts spotlessApply
+```
+
 ## Built With
 
 - [OpenJDK 25](https://openjdk.org/projects/jdk/25/)


### PR DESCRIPTION
## What

Adds a `make setup` target that enables the bundled Spotless pre-commit hook
(`git config core.hooksPath .githooks`), and documents it in the README.

## Why

The pre-commit hook added with the coroutine/WebFlux migration needs
`core.hooksPath` set once per clone. There was no discoverable command for it;
`make setup` makes local style-checking a one-liner that mirrors what CI enforces.

## Notes

- No build change (Spotless still applied only via the vendored init script; the project build stays plugin-free).
- README addition wrapped to the CI markdownlint 80-char limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `make setup` command to configure local Git pre-commit hooks that automatically run code style validation checks before committing, matching CI requirements.

* **Documentation**
  * Updated documentation with setup instructions and guidance for using auto-fix commands to resolve formatting violations locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->