### PR TITLE
feat: local LLM + local image generation (Spring AI, Stable Diffusion, Docker Compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+**/node_modules
+**/dist
+*.db
+docs/superpowers
+.superpowers
+# Do NOT add **/build here. CI builds the Spring Boot jar with Gradle, then
+# beat-the-machine-adapters/Dockerfile (single-stage) COPYs it from
+# beat-the-machine-adapters/build/libs/adapters.jar. Excluding build/ removes
+# that jar from the docker build context and breaks the image build.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Copy this file to .env and fill in the values you need.
+# See README.md "Running with real generation" for the full provider table.
+
+# --- Prompt provider ---
+# Selects the prompt (words) source. Default: seed (no config needed).
+BTM_PROMPT_PROVIDER=ollama
+
+# SPRING_AI_MODEL_CHAT MUST match BTM_PROMPT_PROVIDER.
+# Mismatch causes a boot failure: Spring AI activates the chat auto-config
+# for the declared value; if it doesn't match the provider bean, boot fails.
+#   BTM_PROMPT_PROVIDER=ollama  -> SPRING_AI_MODEL_CHAT=ollama
+#   BTM_PROMPT_PROVIDER=openai  -> SPRING_AI_MODEL_CHAT=openai
+#   BTM_PROMPT_PROVIDER=seed    -> leave unset (or set to none)
+SPRING_AI_MODEL_CHAT=ollama
+
+SPRING_AI_OLLAMA_BASE_URL=http://ollama:11434
+
+# --- Image provider ---
+# Selects the image source. Default: seed (no config needed).
+BTM_IMAGE_PROVIDER=seed
+
+# SPRING_AI_MODEL_IMAGE is only required for BTM_IMAGE_PROVIDER=paid.
+# local-sd uses a plain WebClient; leave this unset for seed or local-sd.
+#   BTM_IMAGE_PROVIDER=paid -> SPRING_AI_MODEL_IMAGE=openai
+# SPRING_AI_MODEL_IMAGE=openai
+
+# SD (local-sd) base URL.
+# Default points to the compose-managed stable-diffusion service.
+# For macOS native A1111 use: http://host.docker.internal:7860
+BTM_IMAGE_LOCAL_SD_BASE_URL=http://stable-diffusion:7860
+
+# --- OpenAI ---
+# Required for BTM_PROMPT_PROVIDER=openai or BTM_IMAGE_PROVIDER=paid.
+# SPRING_AI_OPENAI_API_KEY=sk-...

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Beat The Machine
 
-Backend and player UI for [Beat the machine!](https://beat-the-machine.yonatankarp.com/),
-a hangman-style game played against AI-generated images: guess the words of a
-hidden prompt from the picture before running out of lives.
+Backend and player UI for
+[Beat the machine!](https://beat-the-machine.yonatankarp.com/),
+a hangman-style game played against AI-generated images: guess the words
+of a hidden prompt from the picture before running out of lives.
 
 ## Quick start
 
-Requires JDK 25+ (and Node.js 22+ only for UI development). Tasks run through the
-Makefile; `make help` lists them all.
+Requires JDK 25+ (and Node.js 22+ only for UI development). Tasks run
+through the Makefile; `make help` lists them all.
 
 ```shell
 make run-inmemory   # backend + bundled UI at http://localhost:8080
@@ -32,13 +33,105 @@ domain never depends on a framework:
 - `beat-the-machine-application`: use cases and the outbound ports.
 - `beat-the-machine-adapters`: the Spring Boot app (REST API, persistence, the
   async AI picture pipeline). Also serves the SPA at `/app`.
-- `beat-the-machine-frontend`: the player UI, a React single-page app (SPA) built
-  with Vite and TypeScript, bundled into the backend jar at package time.
+- `beat-the-machine-frontend`: the player UI, a React SPA built with Vite
+  and TypeScript, bundled into the backend jar at package time.
 
 The HTTP API is defined in
-[`docs/openapi/beat-the-machine-openapi.yaml`](docs/openapi/beat-the-machine-openapi.yaml);
-both the Kotlin server models and the frontend client are generated from it. The
-secret prompt is never serialized while a challenge is `IN_PROGRESS`.
+[`docs/openapi/beat-the-machine-openapi.yaml`][openapi];
+both the Kotlin server models and the frontend client are generated from
+it. The secret prompt is never serialized while a challenge is
+`IN_PROGRESS`.
+
+[openapi]: docs/openapi/beat-the-machine-openapi.yaml
+
+## Running with real generation
+
+By default the app uses seed (static) prompts and seed images, so it boots
+with no API keys or GPU. The sections below enable live AI generation.
+
+### One-command local (Ollama + seed images)
+
+```shell
+docker compose up
+docker compose exec ollama ollama pull llama3.2
+```
+
+Open <http://localhost:8080/app/>. Set `BTM_PROMPT_PROVIDER=ollama` and
+`SPRING_AI_MODEL_CHAT=ollama` (see the table below) to switch from seed
+prompts to Ollama-generated ones.
+
+### Real images on Linux / NVIDIA
+
+```shell
+docker compose --profile sd up
+```
+
+Then set `BTM_IMAGE_PROVIDER=local-sd`. No API key needed; the
+Stable Diffusion container is included in the `sd` profile.
+
+### Real images without a GPU (CPU, slow)
+
+For hosts with no NVIDIA GPU — including Apple Silicon, where Docker
+cannot use the Mac GPU:
+
+```shell
+BTM_IMAGE_PROVIDER=local-sd docker compose --profile sd-cpu up
+```
+
+The `stable-diffusion-cpu` service is aliased to the
+`stable-diffusion` hostname so the default
+`BTM_IMAGE_LOCAL_SD_BASE_URL` works unchanged. Caveats:
+
+- Generation is slow (minutes per image). On Apple Silicon the image
+  runs under amd64 emulation — uncomment `platform: linux/amd64` in
+  compose.yaml. Meant for the background pre-seed pool, not live play.
+- First run downloads a Stable Diffusion 1.5 checkpoint (~4 GB).
+- Not runtime-verified in this repo; adjust the image/flags to your
+  chosen A1111 build. Alternative:
+  AbdBarho/stable-diffusion-webui-docker (`--profile auto-cpu`).
+
+### Real images on macOS (Automatic1111 native)
+
+Run Automatic1111 locally with `--api` enabled, then point the backend
+at it:
+
+```shell
+BTM_IMAGE_LOCAL_SD_BASE_URL=http://host.docker.internal:7860 \
+  BTM_IMAGE_PROVIDER=local-sd \
+  docker compose up
+```
+
+### Provider / environment-variable reference
+
+Switching a Spring AI provider requires **two** env vars: one selects
+the adapter, the other activates the matching Spring AI auto-config.
+Missing the second causes a boot failure.
+
+| Variable | Values | Notes |
+|---|---|---|
+| `BTM_PROMPT_PROVIDER` | `seed` (default), `ollama`, `openai` | |
+| `SPRING_AI_MODEL_CHAT` | `ollama`, `openai` | Must match prompt |
+| | | provider (not `seed`) |
+| `BTM_IMAGE_PROVIDER` | `seed` (default), `local-sd`, `paid` | |
+| `SPRING_AI_MODEL_IMAGE` | `openai` | Required for `paid` |
+| `SPRING_AI_OLLAMA_BASE_URL` | e.g. `http://ollama:11434` | Ollama |
+| `BTM_IMAGE_LOCAL_SD_BASE_URL` | e.g. `http://...internal:7860` | SD |
+| `SPRING_AI_OPENAI_API_KEY` | your OpenAI key | `openai` or `paid` |
+
+**Combinations that work:**
+
+- Seed words + seed images (default): boots keyless, no config.
+- Ollama words + seed images:
+  `BTM_PROMPT_PROVIDER=ollama SPRING_AI_MODEL_CHAT=ollama`
+- OpenAI words + seed images:
+  `BTM_PROMPT_PROVIDER=openai SPRING_AI_MODEL_CHAT=openai`
+  `SPRING_AI_OPENAI_API_KEY=<key>`
+- Seed words + local-SD images:
+  `BTM_IMAGE_PROVIDER=local-sd`
+  `BTM_IMAGE_LOCAL_SD_BASE_URL=http://host.docker.internal:7860`
+- Any words + paid (OpenAI DALL-E) images:
+  `BTM_IMAGE_PROVIDER=paid SPRING_AI_MODEL_IMAGE=openai`
+  `SPRING_AI_OPENAI_API_KEY=<key>`
 
 ## Contributing
 

--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -25,8 +25,7 @@ dependencies {
     implementation(libs.bundles.kotlinx.coroutines)
 
     implementation(platform(libs.spring.ai.bom))
-    implementation(libs.spring.ai.starter.model.openai)
-    implementation(libs.spring.ai.starter.model.ollama)
+    implementation(libs.bundles.spring.ai.starters)
 
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.bundles.spring.boot.test) {

--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
     implementation(libs.kotlin.stdlib.jdk8)
     implementation(libs.bundles.kotlinx.coroutines)
 
+    implementation(platform(libs.spring.ai.bom))
+    implementation(libs.spring.ai.starter.model.openai)
+    implementation(libs.spring.ai.starter.model.ollama)
+
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.bundles.spring.boot.test) {
         exclude("org.mockito", "mockito-core")

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
@@ -14,8 +14,6 @@ import com.yonatankarp.beatthemachine.application.usecase.GetChallengeUseCase
 import com.yonatankarp.beatthemachine.application.usecase.MakeGuessUseCase
 import com.yonatankarp.beatthemachine.application.usecase.StartChallengeUseCase
 import com.yonatankarp.beatthemachine.output.ai.PicturePregeneration
-import com.yonatankarp.beatthemachine.output.ai.SeedMachine
-import com.yonatankarp.beatthemachine.output.ai.SeedPromptSource
 import kotlinx.coroutines.launch
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
@@ -23,12 +21,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class BeanConfig {
-    @Bean
-    fun promptSource(): PromptSource = SeedPromptSource()
-
-    @Bean
-    fun machine(): Machine = SeedMachine()
-
     @Bean
     fun pictureScope(): PictureScope = PictureScope()
 

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/InMemoryPersistenceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/InMemoryPersistenceConfig.kt
@@ -2,10 +2,12 @@ package com.yonatankarp.beatthemachine.config
 
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeStore
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPendingChallenges
+import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryPictureStore
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryStoreChallenge
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -25,4 +27,7 @@ class InMemoryPersistenceConfig {
 
     @Bean
     fun findPendingChallenges(store: InMemoryChallengeStore): FindPendingChallenges = InMemoryFindPendingChallenges(store)
+
+    @Bean
+    fun pictureStore(): PictureStore = InMemoryPictureStore()
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/LocalStableDiffusionProperties.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/LocalStableDiffusionProperties.kt
@@ -1,0 +1,12 @@
+package com.yonatankarp.beatthemachine.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "btm.image.local-sd")
+data class LocalStableDiffusionProperties(
+    val baseUrl: String = "http://localhost:7860",
+    val steps: Int = 8,
+    val width: Int = 512,
+    val height: Int = 512,
+    val timeoutSeconds: Long = 120,
+)

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/MachineConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/MachineConfig.kt
@@ -1,0 +1,43 @@
+package com.yonatankarp.beatthemachine.config
+
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.output.ai.LocalStableDiffusionMachine
+import com.yonatankarp.beatthemachine.output.ai.SeedMachine
+import com.yonatankarp.beatthemachine.output.ai.SpringAiImageMachine
+import org.springframework.ai.image.ImageModel
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.time.Duration.Companion.seconds
+
+@Configuration
+@EnableConfigurationProperties(LocalStableDiffusionProperties::class)
+class MachineConfig {
+    @Bean
+    @ConditionalOnProperty(name = ["btm.image.provider"], havingValue = "seed", matchIfMissing = true)
+    fun seedMachine(): Machine = SeedMachine()
+
+    @Bean
+    @ConditionalOnProperty(name = ["btm.image.provider"], havingValue = "local-sd")
+    fun localStableDiffusionMachine(
+        pictureStore: PictureStore,
+        properties: LocalStableDiffusionProperties,
+    ): Machine =
+        LocalStableDiffusionMachine(
+            properties.baseUrl,
+            pictureStore,
+            properties.steps,
+            properties.width,
+            properties.height,
+            properties.timeoutSeconds.seconds,
+        )
+
+    @Bean
+    @ConditionalOnProperty(name = ["btm.image.provider"], havingValue = "paid")
+    fun springAiImageMachine(
+        imageModel: ImageModel,
+        pictureStore: PictureStore,
+    ): Machine = SpringAiImageMachine(imageModel, pictureStore)
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfig.kt
@@ -17,11 +17,12 @@ class PromptSourceConfig {
 
     @Bean
     @ConditionalOnProperty(name = ["btm.prompt.provider"], havingValue = "ollama")
-    fun ollamaPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource =
-        SpringAiPromptSource(ChatClientLlmText(chatClientBuilder.build()), SeedPromptSource())
+    fun ollamaPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource = chatPromptSource(chatClientBuilder)
 
     @Bean
     @ConditionalOnProperty(name = ["btm.prompt.provider"], havingValue = "openai")
-    fun openAiPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource =
+    fun openAiPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource = chatPromptSource(chatClientBuilder)
+
+    private fun chatPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource =
         SpringAiPromptSource(ChatClientLlmText(chatClientBuilder.build()), SeedPromptSource())
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfig.kt
@@ -1,0 +1,27 @@
+package com.yonatankarp.beatthemachine.config
+
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.output.ai.ChatClientLlmText
+import com.yonatankarp.beatthemachine.output.ai.SeedPromptSource
+import com.yonatankarp.beatthemachine.output.ai.SpringAiPromptSource
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class PromptSourceConfig {
+    @Bean
+    @ConditionalOnProperty(name = ["btm.prompt.provider"], havingValue = "seed", matchIfMissing = true)
+    fun seedPromptSource(): PromptSource = SeedPromptSource()
+
+    @Bean
+    @ConditionalOnProperty(name = ["btm.prompt.provider"], havingValue = "ollama")
+    fun ollamaPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource =
+        SpringAiPromptSource(ChatClientLlmText(chatClientBuilder.build()), SeedPromptSource())
+
+    @Bean
+    @ConditionalOnProperty(name = ["btm.prompt.provider"], havingValue = "openai")
+    fun openAiPromptSource(chatClientBuilder: ChatClient.Builder): PromptSource =
+        SpringAiPromptSource(ChatClientLlmText(chatClientBuilder.build()), SeedPromptSource())
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/SqlitePersistenceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/SqlitePersistenceConfig.kt
@@ -2,10 +2,12 @@ package com.yonatankarp.beatthemachine.config
 
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.ChallengeRowMapper
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteFindPendingChallenges
+import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqlitePictureStore
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteStoreChallenge
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -35,4 +37,7 @@ class SqlitePersistenceConfig {
         jdbcTemplate: JdbcTemplate,
         mapper: ChallengeRowMapper,
     ): FindPendingChallenges = SqliteFindPendingChallenges(jdbcTemplate, mapper)
+
+    @Bean
+    fun pictureStore(jdbcTemplate: JdbcTemplate): PictureStore = SqlitePictureStore(jdbcTemplate)
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapper.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapper.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.beatthemachine.input.web
 
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.openapi.v1.models.ChallengeResponse
@@ -18,7 +17,7 @@ fun Challenge.toApiResponse(): ChallengeResponse =
         id = id.value,
         maskedPrompt = maskedPrompt().tokens.map { it.toApi() },
         livesRemaining = lives.remaining,
-        maxLives = Lives.initialFor(difficulty).remaining,
+        maxLives = maxLives().remaining,
         status = ChallengeStatus.valueOf(status.name),
         picture = picture.toApi(),
     )

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
@@ -33,6 +33,7 @@ class PictureController(
     private companion object {
         val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/webp", "image/gif")
         const val FALLBACK_CONTENT_TYPE = "application/octet-stream"
-        const val CACHE_CONTROL_VALUE = "public, max-age=31536000, immutable"
+        const val MAX_AGE_SECONDS = 31536000
+        const val CACHE_CONTROL_VALUE = "public, max-age=$MAX_AGE_SECONDS, immutable"
     }
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
@@ -1,0 +1,38 @@
+package com.yonatankarp.beatthemachine.input.web
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PictureController(
+    private val pictureStore: PictureStore,
+) {
+    @GetMapping("/images/{id}")
+    suspend fun image(
+        @PathVariable id: String,
+    ): ResponseEntity<ByteArray> {
+        val image = pictureStore.load(id) ?: return ResponseEntity.notFound().build()
+        val safeContentType =
+            if (image.contentType in ALLOWED_CONTENT_TYPES) {
+                image.contentType
+            } else {
+                FALLBACK_CONTENT_TYPE
+            }
+        return ResponseEntity
+            .ok()
+            .contentType(MediaType.parseMediaType(safeContentType))
+            .header(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_VALUE)
+            .body(image.bytes)
+    }
+
+    private companion object {
+        val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/webp", "image/gif")
+        const val FALLBACK_CONTENT_TYPE = "application/octet-stream"
+        const val CACHE_CONTROL_VALUE = "public, max-age=31536000, immutable"
+    }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
@@ -25,11 +25,7 @@ class PictureController(
     }
 
     private fun String.toAllowedMediaType(): MediaType =
-        if (this in ALLOWED_CONTENT_TYPES) {
-            MediaType.parseMediaType(this)
-        } else {
-            MediaType.parseMediaType(FALLBACK_CONTENT_TYPE)
-        }
+        MediaType.parseMediaType(takeIf { it in ALLOWED_CONTENT_TYPES } ?: FALLBACK_CONTENT_TYPE)
 
     private companion object {
         val ALLOWED_CONTENT_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/webp", "image/gif")

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/PictureController.kt
@@ -17,21 +17,22 @@ class PictureController(
         @PathVariable id: String,
     ): ResponseEntity<ByteArray> {
         val image = pictureStore.load(id) ?: return ResponseEntity.notFound().build()
-        val safeContentType =
-            if (image.contentType in ALLOWED_CONTENT_TYPES) {
-                image.contentType
-            } else {
-                FALLBACK_CONTENT_TYPE
-            }
         return ResponseEntity
             .ok()
-            .contentType(MediaType.parseMediaType(safeContentType))
+            .contentType(image.contentType.toAllowedMediaType())
             .header(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_VALUE)
             .body(image.bytes)
     }
 
+    private fun String.toAllowedMediaType(): MediaType =
+        if (this in ALLOWED_CONTENT_TYPES) {
+            MediaType.parseMediaType(this)
+        } else {
+            MediaType.parseMediaType(FALLBACK_CONTENT_TYPE)
+        }
+
     private companion object {
-        val ALLOWED_CONTENT_TYPES = setOf("image/png", "image/jpeg", "image/webp", "image/gif")
+        val ALLOWED_CONTENT_TYPES: Set<String> = setOf("image/png", "image/jpeg", "image/webp", "image/gif")
         const val FALLBACK_CONTENT_TYPE = "application/octet-stream"
         const val MAX_AGE_SECONDS = 31536000
         const val CACHE_CONTROL_VALUE = "public, max-age=$MAX_AGE_SECONDS, immutable"

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilter.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilter.kt
@@ -28,7 +28,7 @@ class SecurityHeadersFilter : WebFilter {
             "default-src 'self'; " +
                 "script-src 'self'; " +
                 "style-src 'self' 'unsafe-inline'; " +
-                "img-src 'self' https: data:; " +
+                "img-src 'self' https:; " +
                 "font-src 'self'; " +
                 "connect-src 'self'; " +
                 "object-src 'none'; " +

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChatClientLlmText.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChatClientLlmText.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.ai.chat.client.ChatClient
+
+class ChatClientLlmText(
+    private val chatClient: ChatClient,
+) : LlmText {
+    override suspend fun complete(
+        system: String,
+        user: String,
+    ): String =
+        withContext(Dispatchers.IO) {
+            chatClient
+                .prompt()
+                .system(system)
+                .user(user)
+                .call()
+                .content()
+                .orEmpty()
+        }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
@@ -10,6 +10,10 @@ internal const val MAX_IMAGE_BYTES = 16 * 1024 * 1024
 
 internal const val PNG_CONTENT_TYPE = "image/png"
 
+internal const val IMAGE_PATH_PREFIX = "/images/"
+
+internal fun imageUrl(id: String): String = "$IMAGE_PATH_PREFIX$id"
+
 internal fun imageWebClient(baseUrl: String? = null): WebClient {
     val builder = WebClient.builder()
     if (baseUrl != null) builder.baseUrl(baseUrl)
@@ -25,7 +29,7 @@ internal suspend fun PictureStore.renderedPicture(
 ): Picture =
     try {
         val bytes = produce() ?: return Picture.Failed
-        Picture.Ready(save(bytes, PNG_CONTENT_TYPE))
+        Picture.Ready(imageUrl(save(bytes, PNG_CONTENT_TYPE)))
     } catch (e: Exception) {
         logger.warn("Image generation failed for prompt '{}'", prompt.text, e)
         Picture.Failed

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
@@ -1,0 +1,32 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import org.slf4j.Logger
+import org.springframework.web.reactive.function.client.WebClient
+
+internal const val MAX_IMAGE_BYTES = 16 * 1024 * 1024
+
+internal const val PNG_CONTENT_TYPE = "image/png"
+
+internal fun imageWebClient(baseUrl: String? = null): WebClient {
+    val builder = WebClient.builder()
+    if (baseUrl != null) builder.baseUrl(baseUrl)
+    return builder
+        .codecs { it.defaultCodecs().maxInMemorySize(MAX_IMAGE_BYTES) }
+        .build()
+}
+
+internal suspend fun PictureStore.renderedPicture(
+    logger: Logger,
+    prompt: Prompt,
+    produce: suspend () -> ByteArray?,
+): Picture =
+    try {
+        val bytes = produce() ?: return Picture.Failed
+        Picture.Ready(save(bytes, PNG_CONTENT_TYPE))
+    } catch (e: Exception) {
+        logger.warn("Image generation failed for prompt '{}'", prompt.text, e)
+        Picture.Failed
+    }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LlmText.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LlmText.kt
@@ -1,0 +1,8 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+fun interface LlmText {
+    suspend fun complete(
+        system: String,
+        user: String,
+    ): String
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachine.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachine.kt
@@ -1,0 +1,55 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.slf4j.LoggerFactory
+import org.springframework.web.reactive.function.client.awaitBody
+import java.util.Base64
+import kotlin.time.Duration
+
+class LocalStableDiffusionMachine(
+    baseUrl: String,
+    private val pictureStore: PictureStore,
+    private val steps: Int,
+    private val width: Int,
+    private val height: Int,
+    private val timeout: Duration,
+) : Machine {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val webClient = imageWebClient(baseUrl)
+
+    override suspend fun generate(prompt: Prompt): Picture =
+        pictureStore.renderedPicture(logger, prompt) {
+            val response =
+                withContext(Dispatchers.IO) {
+                    withTimeout(timeout) {
+                        webClient
+                            .post()
+                            .uri("/sdapi/v1/txt2img")
+                            .bodyValue(Txt2ImgRequest(prompt.text, steps, width, height))
+                            .retrieve()
+                            .awaitBody<Txt2ImgResponse>()
+                    }
+                }
+            val b64 = response.images.firstOrNull() ?: return@renderedPicture null
+            Base64.getDecoder().decode(b64)
+        }
+
+    private data class Txt2ImgRequest(
+        val prompt: String,
+        val steps: Int,
+        val width: Int,
+        val height: Int,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class Txt2ImgResponse(
+        val images: List<String> = emptyList(),
+    )
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachine.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachine.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
+import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
 import java.util.Base64
 import kotlin.time.Duration
@@ -29,17 +30,19 @@ class LocalStableDiffusionMachine(
             val response =
                 withContext(Dispatchers.IO) {
                     withTimeout(timeout) {
-                        webClient
-                            .post()
-                            .uri("/sdapi/v1/txt2img")
-                            .bodyValue(Txt2ImgRequest(prompt.text, steps, width, height))
-                            .retrieve()
-                            .awaitBody<Txt2ImgResponse>()
+                        webClient.textToImage(Txt2ImgRequest(prompt.text, steps, width, height))
                     }
                 }
             val b64 = response.images.firstOrNull() ?: return@renderedPicture null
             Base64.getDecoder().decode(b64)
         }
+
+    private suspend fun WebClient.textToImage(request: Txt2ImgRequest): Txt2ImgResponse =
+        post()
+            .uri("/sdapi/v1/txt2img")
+            .bodyValue(request)
+            .retrieve()
+            .awaitBody()
 
     private data class Txt2ImgRequest(
         val prompt: String,

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
@@ -1,0 +1,49 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import org.springframework.ai.image.Image
+import org.springframework.ai.image.ImageModel
+import org.springframework.ai.image.ImagePrompt
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import java.util.Base64
+
+class SpringAiImageMachine(
+    private val imageModel: ImageModel,
+    private val pictureStore: PictureStore,
+) : Machine {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val webClient = imageWebClient()
+
+    override suspend fun generate(prompt: Prompt): Picture =
+        pictureStore.renderedPicture(logger, prompt) {
+            withContext(Dispatchers.IO) {
+                imageModel.call(ImagePrompt(prompt.text)).result?.output
+            }?.resolvedBytes(webClient)
+        }
+
+    private suspend fun Image.resolvedBytes(client: WebClient): ByteArray? =
+        when {
+            !b64Json.isNullOrBlank() -> {
+                Base64.getDecoder().decode(b64Json)
+            }
+
+            !url.isNullOrBlank() -> {
+                client
+                    .get()
+                    .uri(url!!)
+                    .retrieve()
+                    .awaitBody<ByteArray>()
+            }
+
+            else -> {
+                null
+            }
+        }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
@@ -17,25 +17,25 @@ import java.util.Base64
 class SpringAiImageMachine(
     private val imageModel: ImageModel,
     private val pictureStore: PictureStore,
+    private val webClient: WebClient = imageWebClient(),
 ) : Machine {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val webClient = imageWebClient()
 
     override suspend fun generate(prompt: Prompt): Picture =
         pictureStore.renderedPicture(logger, prompt) {
             withContext(Dispatchers.IO) {
                 imageModel.call(ImagePrompt(prompt.text)).result?.output
-            }?.resolvedBytes(webClient)
+            }?.resolvedBytes()
         }
 
-    private suspend fun Image.resolvedBytes(client: WebClient): ByteArray? =
+    private suspend fun Image.resolvedBytes(): ByteArray? =
         when {
             !b64Json.isNullOrBlank() -> {
                 Base64.getDecoder().decode(b64Json)
             }
 
             !url.isNullOrBlank() -> {
-                client
+                webClient
                     .get()
                     .uri(url!!)
                     .retrieve()

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
@@ -51,7 +51,7 @@ class SpringAiPromptSource(
         val EASY_BAND = 1..2
         val MEDIUM_BAND = 2..3
         val HARD_BAND = 3..5
-        val WHITESPACE_REGEX = Regex("\\s+")
+        val WHITESPACE_REGEX = """\s+""".toRegex()
         const val SYSTEM_PROMPT =
             "You generate short, concrete, family-friendly subjects for an AI image-guessing game. " +
                 "Favour vivid, drawable nouns and scenes. Never use proper names or offensive content."

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
@@ -14,9 +14,10 @@ class SpringAiPromptSource(
 
     override suspend infix fun next(difficulty: Difficulty): Prompt {
         val band = bandFor(difficulty)
+        val userMessage = userPrompt(difficulty, band)
         repeat(maxAttempts) { attempt ->
             val candidate =
-                runCatching { llm.complete(SYSTEM_PROMPT, userPrompt(difficulty, band)) }
+                runCatching { llm.complete(SYSTEM_PROMPT, userMessage) }
                     .getOrElse { llmError ->
                         logger.warn("LLM call failed (attempt {}/{})", attempt + 1, maxAttempts, llmError)
                         return@repeat

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSource.kt
@@ -1,0 +1,59 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import org.slf4j.LoggerFactory
+
+class SpringAiPromptSource(
+    private val llm: LlmText,
+    private val fallback: PromptSource,
+    private val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+) : PromptSource {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override suspend infix fun next(difficulty: Difficulty): Prompt {
+        val band = bandFor(difficulty)
+        repeat(maxAttempts) { attempt ->
+            val candidate =
+                runCatching { llm.complete(SYSTEM_PROMPT, userPrompt(difficulty, band)) }
+                    .getOrElse { llmError ->
+                        logger.warn("LLM call failed (attempt {}/{})", attempt + 1, maxAttempts, llmError)
+                        return@repeat
+                    }
+            val phrase = candidate.trim()
+            if (phrase.isNotBlank() && phrase.split(WHITESPACE_REGEX).size in band) {
+                return Prompt(phrase)
+            }
+            logger.info("Discarding out-of-band LLM phrase: '{}'", phrase)
+        }
+        logger.warn("LLM produced no valid phrase in {} attempts; using fallback", maxAttempts)
+        return fallback next difficulty
+    }
+
+    private fun userPrompt(
+        difficulty: Difficulty,
+        band: IntRange,
+    ): String =
+        "Give exactly one concrete, visually depictable ${difficulty.name.lowercase()} subject " +
+            "for an AI image, between ${band.first} and ${band.last} words. " +
+            "Reply with only the phrase, no punctuation, no quotes, no explanation."
+
+    private fun bandFor(difficulty: Difficulty): IntRange =
+        when (difficulty) {
+            Difficulty.EASY -> EASY_BAND
+            Difficulty.MEDIUM -> MEDIUM_BAND
+            Difficulty.HARD -> HARD_BAND
+        }
+
+    private companion object {
+        const val DEFAULT_MAX_ATTEMPTS = 3
+        val EASY_BAND = 1..2
+        val MEDIUM_BAND = 2..3
+        val HARD_BAND = 3..5
+        val WHITESPACE_REGEX = Regex("\\s+")
+        const val SYSTEM_PROMPT =
+            "You generate short, concrete, family-friendly subjects for an AI image-guessing game. " +
+                "Favour vivid, drawable nouns and scenes. Never use proper names or offensive content."
+    }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStore.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStore.kt
@@ -1,0 +1,21 @@
+package com.yonatankarp.beatthemachine.output.persistence.inmemory
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.application.port.output.StoredImage
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class InMemoryPictureStore : PictureStore {
+    private val byId = ConcurrentHashMap<String, StoredImage>()
+
+    override suspend fun save(
+        bytes: ByteArray,
+        contentType: String,
+    ): String {
+        val id = UUID.randomUUID().toString()
+        byId[id] = StoredImage(bytes.copyOf(), contentType)
+        return "/images/$id"
+    }
+
+    override suspend fun load(id: String): StoredImage? = byId[id]
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStore.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStore.kt
@@ -14,7 +14,7 @@ class InMemoryPictureStore : PictureStore {
     ): String {
         val id = UUID.randomUUID().toString()
         byId[id] = StoredImage(bytes.copyOf(), contentType)
-        return "/images/$id"
+        return id
     }
 
     override suspend fun load(id: String): StoredImage? = byId[id]

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStore.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStore.kt
@@ -1,0 +1,37 @@
+package com.yonatankarp.beatthemachine.output.persistence.sqlite
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.application.port.output.StoredImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.UUID
+
+class SqlitePictureStore(
+    private val jdbc: JdbcTemplate,
+) : PictureStore {
+    override suspend fun save(
+        bytes: ByteArray,
+        contentType: String,
+    ): String =
+        withContext(Dispatchers.IO) {
+            val id = UUID.randomUUID().toString()
+            jdbc.update(
+                "INSERT OR REPLACE INTO picture (id, bytes, content_type) VALUES (?, ?, ?)",
+                id,
+                bytes,
+                contentType,
+            )
+            "/images/$id"
+        }
+
+    override suspend fun load(id: String): StoredImage? =
+        withContext(Dispatchers.IO) {
+            jdbc
+                .query(
+                    "SELECT bytes, content_type FROM picture WHERE id = ?",
+                    { rs, _ -> StoredImage(rs.getBytes("bytes"), rs.getString("content_type")) },
+                    id,
+                ).firstOrNull()
+        }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStore.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStore.kt
@@ -22,7 +22,7 @@ class SqlitePictureStore(
                 bytes,
                 contentType,
             )
-            "/images/$id"
+            id
         }
 
     override suspend fun load(id: String): StoredImage? =

--- a/beat-the-machine-adapters/src/main/resources/application.yml
+++ b/beat-the-machine-adapters/src/main/resources/application.yml
@@ -21,6 +21,16 @@ spring:
 
 btm:
   persistence: sqlite
+  prompt:
+    provider: ${BTM_PROMPT_PROVIDER:seed}
+  image:
+    provider: ${BTM_IMAGE_PROVIDER:seed}
+    local-sd:
+      base-url: ${BTM_IMAGE_LOCAL_SD_BASE_URL:http://localhost:7860}
+      steps: ${BTM_IMAGE_LOCAL_SD_STEPS:8}
+      width: ${BTM_IMAGE_LOCAL_SD_WIDTH:512}
+      height: ${BTM_IMAGE_LOCAL_SD_HEIGHT:512}
+      timeout-seconds: ${BTM_IMAGE_LOCAL_SD_TIMEOUT_SECONDS:120}
 
 management:
   endpoints:

--- a/beat-the-machine-adapters/src/main/resources/application.yml
+++ b/beat-the-machine-adapters/src/main/resources/application.yml
@@ -2,6 +2,15 @@ server:
   port: ${PORT:80}
 
 spring:
+  ai:
+    model:
+      chat: ${SPRING_AI_MODEL_CHAT:none}
+      image: ${SPRING_AI_MODEL_IMAGE:none}
+      embedding: ${SPRING_AI_MODEL_EMBEDDING:none}
+      audio:
+        speech: ${SPRING_AI_MODEL_AUDIO_SPEECH:none}
+        transcription: ${SPRING_AI_MODEL_AUDIO_TRANSCRIPTION:none}
+      moderation: ${SPRING_AI_MODEL_MODERATION:none}
   datasource:
     url: jdbc:sqlite:${BTM_DB_PATH:beat-the-machine.db}
     driver-class-name: org.sqlite.JDBC

--- a/beat-the-machine-adapters/src/main/resources/schema.sql
+++ b/beat-the-machine-adapters/src/main/resources/schema.sql
@@ -9,3 +9,9 @@ CREATE TABLE IF NOT EXISTS challenge (
     difficulty     TEXT    NOT NULL,
     version        INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS picture (
+    id           TEXT PRIMARY KEY,
+    bytes        BLOB NOT NULL,
+    content_type TEXT NOT NULL
+);

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
@@ -1,0 +1,42 @@
+package com.yonatankarp.beatthemachine.config
+
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.application.port.output.StoredImage
+import com.yonatankarp.beatthemachine.output.ai.SeedMachine
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.test.assertTrue
+
+class MachineConfigTest {
+    private val runner = ApplicationContextRunner().withUserConfiguration(MachineConfig::class.java)
+
+    @Test
+    fun `defaults to the seed machine`() {
+        runner.run { ctx -> assertTrue(ctx.getBean(Machine::class.java) is SeedMachine) }
+    }
+
+    @Test
+    fun `selects local-sd when configured`() {
+        runner
+            .withUserConfiguration(StubPictureStoreConfig::class.java)
+            .withPropertyValues("btm.image.provider=local-sd", "btm.image.local-sd.base-url=http://localhost:7860")
+            .run { ctx -> assertTrue(ctx.getBean(Machine::class.java)::class.simpleName == "LocalStableDiffusionMachine") }
+    }
+
+    @Configuration
+    class StubPictureStoreConfig {
+        @Bean
+        fun pictureStore(): PictureStore =
+            object : PictureStore {
+                override suspend fun save(
+                    bytes: ByteArray,
+                    contentType: String,
+                ): String = "stub-url"
+
+                override suspend fun load(id: String): StoredImage? = null
+            }
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
@@ -1,0 +1,16 @@
+package com.yonatankarp.beatthemachine.config
+
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.output.ai.SeedPromptSource
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import kotlin.test.assertTrue
+
+class PromptSourceConfigTest {
+    private val runner = ApplicationContextRunner().withUserConfiguration(PromptSourceConfig::class.java)
+
+    @Test
+    fun `defaults to the seed prompt source`() {
+        runner.run { ctx -> assertTrue(ctx.getBean(PromptSource::class.java) is SeedPromptSource) }
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -108,7 +108,7 @@ class ChallengeApiMapperTest {
     }
 
     @Test
-    fun `maps livesRemaining and the difficulty-derived maxLives`() {
+    fun `maps livesRemaining and the prompt-derived maxLives`() {
         // Given
         val mediumChallenge = mediumChallenge()
         val easyChallenge = easyChallenge()
@@ -119,8 +119,8 @@ class ChallengeApiMapperTest {
 
         // Then
         assertEquals(6, medium.livesRemaining)
-        assertEquals(6, medium.maxLives)
-        assertEquals(8, easy.maxLives)
+        assertEquals(mediumChallenge.maxLives().remaining, medium.maxLives)
+        assertEquals(easyChallenge.maxLives().remaining, easy.maxLives)
     }
 
     @Test

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -7,17 +7,17 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(ForfeitChallengeController::class)
+@MockkBean(types = [ForfeitChallenge::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class ForfeitChallengeControllerTest(
-    @Autowired val client: WebTestClient,
+    private val client: WebTestClient,
+    private val forfeitChallenge: ForfeitChallenge,
 ) {
-    @MockkBean
-    lateinit var forfeitChallenge: ForfeitChallenge
-
     @Test
     fun `forfeit reveals the prompt and reports LOST`() {
         coEvery { forfeitChallenge(any()) } returns lostChallenge()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -7,17 +7,17 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(GetChallengeController::class)
+@MockkBean(types = [GetChallenge::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class GetChallengeControllerTest(
-    @Autowired val client: WebTestClient,
+    private val client: WebTestClient,
+    private val getChallenge: GetChallenge,
 ) {
-    @MockkBean
-    lateinit var getChallenge: GetChallenge
-
     @Test
     fun `GET returns the challenge state`() {
         val challenge = mediumChallenge()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -11,18 +11,18 @@ import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.http.MediaType
+import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(MakeGuessController::class)
+@MockkBean(types = [MakeGuess::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class MakeGuessControllerTest(
-    @Autowired val client: WebTestClient,
+    private val client: WebTestClient,
+    private val makeGuess: MakeGuess,
 ) {
-    @MockkBean
-    lateinit var makeGuess: MakeGuess
-
     @Test
     fun `a successful guess returns the updated masked prompt`() {
         val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
@@ -1,0 +1,80 @@
+package com.yonatankarp.beatthemachine.input.web
+
+import com.ninjasquad.springmockk.MockkBean
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.application.port.output.StoredImage
+import io.mockk.coEvery
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@WebFluxTest(PictureController::class)
+class PictureControllerTest(
+    @Autowired val client: WebTestClient,
+) {
+    @MockkBean
+    lateinit var pictureStore: PictureStore
+
+    @Test
+    fun `serves image bytes with correct content-type`() {
+        // Given
+        coEvery { pictureStore.load("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "image/png")
+
+        // When
+        val response =
+            client
+                .get()
+                .uri("/images/abc")
+                .exchange()
+
+        // Then
+        response
+            .expectStatus()
+            .isOk
+            .expectHeader()
+            .contentType("image/png")
+            .expectHeader()
+            .valueEquals("Cache-Control", "public, max-age=31536000, immutable")
+            .expectBody()
+            .consumeWith { assert(it.responseBody!!.contentEquals(byteArrayOf(1, 2, 3))) }
+    }
+
+    @Test
+    fun `returns 404 for unknown id`() {
+        // Given
+        coEvery { pictureStore.load("unknown") } returns null
+
+        // When
+        val response =
+            client
+                .get()
+                .uri("/images/unknown")
+                .exchange()
+
+        // Then
+        response
+            .expectStatus()
+            .isNotFound
+    }
+
+    @Test
+    fun `coerces non-image content-type to application octet-stream`() {
+        // Given
+        coEvery { pictureStore.load("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "text/plain")
+
+        // When
+        val response =
+            client
+                .get()
+                .uri("/images/abc")
+                .exchange()
+
+        // Then
+        response
+            .expectStatus()
+            .isOk
+            .expectHeader()
+            .contentType("application/octet-stream")
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import kotlin.test.assertContentEquals
 
 @WebFluxTest(PictureController::class)
 class PictureControllerTest(
@@ -36,8 +38,8 @@ class PictureControllerTest(
             .contentType("image/png")
             .expectHeader()
             .valueEquals("Cache-Control", "public, max-age=31536000, immutable")
-            .expectBody()
-            .consumeWith { assert(it.responseBody!!.contentEquals(byteArrayOf(1, 2, 3))) }
+            .expectBody<ByteArray>()
+            .consumeWith { assertContentEquals(byteArrayOf(1, 2, 3), it.responseBody) }
     }
 
     @Test

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
@@ -5,19 +5,19 @@ import com.yonatankarp.beatthemachine.application.port.output.PictureStore
 import com.yonatankarp.beatthemachine.application.port.output.StoredImage
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import kotlin.test.assertContentEquals
 
 @WebFluxTest(PictureController::class)
+@MockkBean(types = [PictureStore::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class PictureControllerTest(
-    @Autowired val client: WebTestClient,
+    private val client: WebTestClient,
+    private val pictureStore: PictureStore,
 ) {
-    @MockkBean
-    lateinit var pictureStore: PictureStore
-
     @Test
     fun `serves image bytes with correct content-type`() {
         // Given

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
+import kotlin.test.assertContains
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
@@ -23,11 +24,11 @@ class SecurityHeadersFilterTest(
             .valueEquals("Referrer-Policy", "no-referrer")
             .expectHeader()
             .value("Content-Security-Policy") { csp ->
-                require("default-src 'self'" in csp) { "missing default-src: $csp" }
-                require("script-src 'self'" in csp) { "missing script-src: $csp" }
-                require("frame-ancestors 'none'" in csp) { "missing frame-ancestors: $csp" }
-                require("object-src 'none'" in csp) { "missing object-src: $csp" }
-                require("img-src 'self' https:" in csp) { "missing img-src: $csp" }
+                assertContains(csp, "default-src 'self'")
+                assertContains(csp, "script-src 'self'")
+                assertContains(csp, "frame-ancestors 'none'")
+                assertContains(csp, "object-src 'none'")
+                assertContains(csp, "img-src 'self' https:")
             }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
@@ -27,7 +27,7 @@ class SecurityHeadersFilterTest(
                 require("script-src 'self'" in csp) { "missing script-src: $csp" }
                 require("frame-ancestors 'none'" in csp) { "missing frame-ancestors: $csp" }
                 require("object-src 'none'" in csp) { "missing object-src: $csp" }
-                require("img-src 'self' https: data:" in csp) { "missing img-src: $csp" }
+                require("img-src 'self' https:" in csp) { "missing img-src: $csp" }
             }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -5,17 +5,17 @@ import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
+import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(StartChallengeController::class)
+@MockkBean(types = [StartChallenge::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class StartChallengeControllerTest(
-    @Autowired val client: WebTestClient,
+    private val client: WebTestClient,
+    private val startChallenge: StartChallenge,
 ) {
-    @MockkBean
-    lateinit var startChallenge: StartChallenge
-
     @Test
     fun `POST creates a challenge and never leaks the prompt`() {
         coEvery { startChallenge(any()) } returns mediumChallenge()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
@@ -1,0 +1,84 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class LocalStableDiffusionMachineTest {
+    private lateinit var server: MockWebServer
+    private val pictureStore = mockk<PictureStore>()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun machine(): LocalStableDiffusionMachine =
+        LocalStableDiffusionMachine(
+            server.url("/").toString(),
+            pictureStore,
+            steps = 8,
+            width = 512,
+            height = 512,
+            timeout = 5.seconds,
+        )
+
+    @Test
+    fun `stores the decoded image and returns Ready`() =
+        runTest {
+            // Given
+            val pngBytes = byteArrayOf(1, 2, 3)
+            val b64 = Base64.getEncoder().encodeToString(pngBytes)
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("""{"images":["$b64"]}"""),
+            )
+            coEvery { pictureStore.save(pngBytes, "image/png") } returns "/images/xyz"
+
+            // When
+            val result = machine().generate(Prompt("dragon eating a cookie"))
+
+            // Then
+            assertEquals(Picture.Ready("/images/xyz"), result)
+        }
+
+    @Test
+    fun `server error yields Failed`() =
+        runTest {
+            // Given
+            server.enqueue(MockResponse().setResponseCode(500))
+
+            // When / Then
+            assertEquals(Picture.Failed, machine().generate(Prompt("anything")))
+        }
+
+    @Test
+    fun `empty image list yields Failed`() =
+        runTest {
+            // Given
+            server.enqueue(
+                MockResponse().setHeader("Content-Type", "application/json").setBody("""{"images":[]}"""),
+            )
+
+            // When / Then
+            assertEquals(Picture.Failed, machine().generate(Prompt("anything")))
+        }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
@@ -8,27 +8,15 @@ import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.util.Base64
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class LocalStableDiffusionMachineTest {
-    private lateinit var server: MockWebServer
     private val pictureStore = mockk<PictureStore>()
-
-    @BeforeEach
-    fun setUp() {
-        server = MockWebServer()
-        server.start()
-    }
-
-    @AfterEach
-    fun tearDown() {
-        server.shutdown()
-    }
 
     private fun machine(): LocalStableDiffusionMachine =
         LocalStableDiffusionMachine(
@@ -51,7 +39,7 @@ class LocalStableDiffusionMachineTest {
                     .setHeader("Content-Type", "application/json")
                     .setBody("""{"images":["$b64"]}"""),
             )
-            coEvery { pictureStore.save(pngBytes, "image/png") } returns "/images/xyz"
+            coEvery { pictureStore.save(pngBytes, "image/png") } returns "xyz"
 
             // When
             val result = machine().generate(Prompt("dragon eating a cookie"))
@@ -81,4 +69,20 @@ class LocalStableDiffusionMachineTest {
             // When / Then
             assertEquals(Picture.Failed, machine().generate(Prompt("anything")))
         }
+
+    companion object {
+        private val server = MockWebServer()
+
+        @JvmStatic
+        @BeforeAll
+        fun startServer() {
+            server.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopServer() {
+            server.shutdown()
+        }
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
@@ -6,7 +6,10 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Test
 import org.springframework.ai.image.Image
 import org.springframework.ai.image.ImageGeneration
@@ -14,6 +17,7 @@ import org.springframework.ai.image.ImageModel
 import org.springframework.ai.image.ImageResponse
 import java.util.Base64
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SpringAiImageMachineTest {
     private val pictureStore = mockk<PictureStore>()
@@ -25,7 +29,7 @@ class SpringAiImageMachineTest {
             // Given
             val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
             every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
-            coEvery { pictureStore.save(any(), "image/png") } returns "/images/paid1"
+            coEvery { pictureStore.save(any(), "image/png") } returns "paid1"
 
             // When
             val machine = SpringAiImageMachine(imageModel, pictureStore)
@@ -33,6 +37,29 @@ class SpringAiImageMachineTest {
 
             // Then
             assertEquals(Picture.Ready("/images/paid1"), result)
+        }
+
+    @Test
+    fun `fetches image bytes when the model returns a url`() =
+        runTest {
+            // Given
+            val server = MockWebServer()
+            server.start()
+            val pngBytes = "PNGDATA".toByteArray()
+            server.enqueue(MockResponse().setBody("PNGDATA"))
+            every { imageModel.call(any()) } returns
+                ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
+            val saved = slot<ByteArray>()
+            coEvery { pictureStore.save(capture(saved), "image/png") } returns "paid2"
+
+            // When
+            val machine = SpringAiImageMachine(imageModel, pictureStore, imageWebClient())
+            val result = machine.generate(Prompt("astronaut eating the moon"))
+
+            // Then
+            assertEquals(Picture.Ready("/images/paid2"), result)
+            assertTrue(pngBytes.contentEquals(saved.captured))
+            server.shutdown()
         }
 
     @Test

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
@@ -1,0 +1,50 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.PictureStore
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.springframework.ai.image.Image
+import org.springframework.ai.image.ImageGeneration
+import org.springframework.ai.image.ImageModel
+import org.springframework.ai.image.ImageResponse
+import java.util.Base64
+import kotlin.test.assertEquals
+
+class SpringAiImageMachineTest {
+    private val pictureStore = mockk<PictureStore>()
+    private val imageModel = mockk<ImageModel>()
+
+    @Test
+    fun `decodes b64 image, stores it, and returns Ready`() =
+        runTest {
+            // Given
+            val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
+            every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
+            coEvery { pictureStore.save(any(), "image/png") } returns "/images/paid1"
+
+            // When
+            val machine = SpringAiImageMachine(imageModel, pictureStore)
+            val result = machine.generate(Prompt("astronaut eating the moon"))
+
+            // Then
+            assertEquals(Picture.Ready("/images/paid1"), result)
+        }
+
+    @Test
+    fun `model failure yields Failed`() =
+        runTest {
+            // Given
+            every { imageModel.call(any()) } throws RuntimeException("boom")
+
+            // When
+            val machine = SpringAiImageMachine(imageModel, pictureStore)
+
+            // Then
+            assertEquals(Picture.Failed, machine.generate(Prompt("anything")))
+        }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
@@ -1,0 +1,73 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SpringAiPromptSourceTest {
+    private val fallback = mockk<PromptSource>()
+
+    @Test
+    fun `returns a valid phrase trimmed to the difficulty band`() =
+        runTest {
+            // Given
+            val llm = LlmText { _, _ -> "  dragon eating a cookie  " }
+            val source = SpringAiPromptSource(llm, fallback)
+
+            // When
+            val result = source next Difficulty.HARD
+
+            // Then
+            assertEquals(Prompt("dragon eating a cookie"), result)
+        }
+
+    @Test
+    fun `retries past empty output then returns first in-band phrase`() =
+        runTest {
+            // Given
+            var calls = 0
+            val llm = LlmText { _, _ -> if (calls++ == 0) "" else "ocean wave" }
+            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 3)
+
+            // When
+            val result = source next Difficulty.EASY
+
+            // Then
+            assertEquals(Prompt("ocean wave"), result)
+        }
+
+    @Test
+    fun `falls back to seed source when the model keeps throwing`() =
+        runTest {
+            // Given
+            val llm = LlmText { _, _ -> throw RuntimeException("model down") }
+            coEvery { fallback next Difficulty.MEDIUM } returns Prompt("dolphin on fire")
+            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+
+            // When
+            val result = source next Difficulty.MEDIUM
+
+            // Then
+            assertEquals(Prompt("dolphin on fire"), result)
+        }
+
+    @Test
+    fun `falls back when output never fits the difficulty band`() =
+        runTest {
+            // Given
+            val llm = LlmText { _, _ -> "this phrase is far too many words to be easy" }
+            coEvery { fallback next Difficulty.EASY } returns Prompt("red car")
+            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+
+            // When
+            val result = source next Difficulty.EASY
+
+            // Then
+            assertEquals(Prompt("red car"), result)
+        }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStoreTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStoreTest.kt
@@ -10,17 +10,15 @@ class InMemoryPictureStoreTest {
     private val store = InMemoryPictureStore()
 
     @Test
-    fun `save returns an images url and load round-trips`() =
+    fun `save returns an id and load round-trips`() =
         runTest {
             // Given
             val bytes = byteArrayOf(9, 8, 7)
 
             // When
-            val url = store.save(bytes, "image/png")
+            val id = store.save(bytes, "image/png")
 
             // Then
-            assertTrue(url.startsWith("/images/"))
-            val id = url.removePrefix("/images/")
             val loaded = store.load(id)!!
             assertEquals("image/png", loaded.contentType)
             assertTrue(bytes.contentEquals(loaded.bytes))

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStoreTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryPictureStoreTest.kt
@@ -1,0 +1,35 @@
+package com.yonatankarp.beatthemachine.output.persistence.inmemory
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InMemoryPictureStoreTest {
+    private val store = InMemoryPictureStore()
+
+    @Test
+    fun `save returns an images url and load round-trips`() =
+        runTest {
+            // Given
+            val bytes = byteArrayOf(9, 8, 7)
+
+            // When
+            val url = store.save(bytes, "image/png")
+
+            // Then
+            assertTrue(url.startsWith("/images/"))
+            val id = url.removePrefix("/images/")
+            val loaded = store.load(id)!!
+            assertEquals("image/png", loaded.contentType)
+            assertTrue(bytes.contentEquals(loaded.bytes))
+        }
+
+    @Test
+    fun `load returns null for unknown id`() =
+        runTest {
+            // When / Then
+            assertNull(store.load("nope"))
+        }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-class SqliteFindChallengeByIdIT {
+class SqliteFindChallengeByIdIntegrationTest {
     private lateinit var storeChallenge: SqliteStoreChallenge
     private lateinit var findChallengeById: SqliteFindChallengeById
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class SqliteFindPendingChallengesIT {
+class SqliteFindPendingChallengesIntegrationTest {
     private lateinit var storeChallenge: SqliteStoreChallenge
     private lateinit var findPendingChallenges: SqliteFindPendingChallenges
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIT.kt
@@ -1,0 +1,48 @@
+package com.yonatankarp.beatthemachine.output.persistence.sqlite
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SqlitePictureStoreIT {
+    private val jdbc = newSqliteJdbc()
+    private val store = SqlitePictureStore(jdbc)
+
+    @Test
+    fun `save then load round-trips the bytes and content type`() =
+        runTest {
+            // Given
+            val bytes = byteArrayOf(1, 2, 3, 4)
+
+            // When
+            val url = store.save(bytes, "image/png")
+            val id = url.removePrefix("/images/")
+            val loaded = store.load(id)!!
+
+            // Then
+            assertEquals("image/png", loaded.contentType)
+            assertTrue(bytes.contentEquals(loaded.bytes))
+        }
+
+    @Test
+    fun `bytes live in the picture table, not on challenge`() =
+        runTest {
+            // Given / When
+            store.save(byteArrayOf(1), "image/png")
+
+            // Then
+            val pictureRows = jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
+            val challengeRows = jdbc.queryForObject("SELECT COUNT(*) FROM challenge", Int::class.java)
+            assertEquals(1, pictureRows)
+            assertEquals(0, challengeRows)
+        }
+
+    @Test
+    fun `load returns null for unknown id`() =
+        runTest {
+            // When / Then
+            assertNull(store.load("missing"))
+        }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIT.kt
@@ -17,8 +17,7 @@ class SqlitePictureStoreIT {
             val bytes = byteArrayOf(1, 2, 3, 4)
 
             // When
-            val url = store.save(bytes, "image/png")
-            val id = url.removePrefix("/images/")
+            val id = store.save(bytes, "image/png")
             val loaded = store.load(id)!!
 
             // Then

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqlitePictureStoreIntegrationTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class SqlitePictureStoreIT {
+class SqlitePictureStoreIntegrationTest {
     private val jdbc = newSqliteJdbc()
     private val store = SqlitePictureStore(jdbc)
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
-class SqliteStoreChallengeIT {
+class SqliteStoreChallengeIntegrationTest {
     private lateinit var storeChallenge: SqliteStoreChallenge
     private lateinit var findChallengeById: SqliteFindChallengeById
 

--- a/beat-the-machine-adapters/src/test/resources/application.yml
+++ b/beat-the-machine-adapters/src/test/resources/application.yml
@@ -1,4 +1,15 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiImageAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionAutoConfiguration
+      - org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration
+      - org.springframework.ai.model.ollama.autoconfigure.OllamaApiAutoConfiguration
+      - org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration
+      - org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration
   datasource:
     url: "jdbc:sqlite::memory:"
     driver-class-name: org.sqlite.JDBC

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/PictureStore.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/PictureStore.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.beatthemachine.application.port.output
+
+interface PictureStore {
+    suspend fun save(
+        bytes: ByteArray,
+        contentType: String,
+    ): String
+
+    suspend fun load(id: String): StoredImage?
+}
+
+class StoredImage(
+    val bytes: ByteArray,
+    val contentType: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is StoredImage) return false
+        return contentType == other.contentType && bytes.contentEquals(other.bytes)
+    }
+
+    override fun hashCode(): Int = 31 * bytes.contentHashCode() + contentType.hashCode()
+}

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCase.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCase.kt
@@ -7,6 +7,7 @@ import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 
 class StartChallengeUseCase(
     private val promptSource: PromptSource,
@@ -14,7 +15,8 @@ class StartChallengeUseCase(
     private val enqueuePicture: (ChallengeId) -> Unit,
 ) : StartChallenge {
     override suspend fun invoke(difficulty: Difficulty): Challenge {
-        val challenge = Challenge.start(promptSource next difficulty, Lives.initialFor(difficulty))
+        val prompt = promptSource next difficulty
+        val challenge = Challenge.start(prompt, Lives.forSecret(prompt, difficulty), difficulty = difficulty)
         val persisted = storeChallenge(challenge)
         enqueuePicture(persisted.id)
         return persisted

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -1,18 +1,22 @@
 package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.application.port.output.StoredImage
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class StartChallengeUseCaseTest {
-    private val prompts = PromptSource { "hello world".asPrompt() }
+    private val fakePrompt = "hello world".asPrompt()
+    private val prompts = PromptSource { fakePrompt }
     private val store = FakeChallengeStore()
 
     @Test
@@ -31,4 +35,34 @@ class StartChallengeUseCaseTest {
             assertEquals(listOf(challenge.id), enqueued)
             assertTrue(store.byId.containsKey(challenge.id))
         }
+
+    @Test
+    fun `starting lives scale with difficulty`() =
+        runTest {
+            // Given
+            val startChallenge = StartChallengeUseCase(prompts, store) {}
+
+            // When
+            val easy = startChallenge(Difficulty.EASY)
+            val medium = startChallenge(Difficulty.MEDIUM)
+            val hard = startChallenge(Difficulty.HARD)
+
+            // Then
+            assertEquals(Lives.forSecret(fakePrompt, Difficulty.EASY).remaining, easy.lives.remaining)
+            assertEquals(Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining, medium.lives.remaining)
+            assertEquals(Lives.forSecret(fakePrompt, Difficulty.HARD).remaining, hard.lives.remaining)
+        }
+
+    @Test
+    fun `StoredImage equality is content-based`() {
+        // Given
+        val a = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+        val b = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+        val c = StoredImage(byteArrayOf(9), "image/png")
+
+        // When / Then
+        assertEquals(a, b)
+        assertNotEquals(a, c)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
 }

--- a/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/entity/Challenge.kt
+++ b/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/entity/Challenge.kt
@@ -28,6 +28,8 @@ class Challenge private constructor(
             MaskedPrompt.of(prompt, guesses)
         }
 
+    fun maxLives(): Lives = Lives.forSecret(prompt, difficulty)
+
     fun makeGuess(guess: Guess): Pair<Challenge, GuessOutcome> {
         if (status != ChallengeStatus.IN_PROGRESS) throw ChallengeAlreadyOver(id)
         val normalized = guess.normalized()

--- a/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Difficulty.kt
+++ b/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Difficulty.kt
@@ -1,7 +1,9 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
-enum class Difficulty {
-    EASY,
-    MEDIUM,
-    HARD,
+enum class Difficulty(
+    val livesMultiplier: Double,
+) {
+    EASY(1.5),
+    MEDIUM(1.0),
+    HARD(0.7),
 }

--- a/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Lives.kt
+++ b/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Lives.kt
@@ -18,13 +18,6 @@ value class Lives(
         private const val PER_WORD_BASE = 3
         private const val MIN_LIVES = 2
 
-        fun initialFor(difficulty: Difficulty): Lives =
-            when (difficulty) {
-                Difficulty.EASY -> Lives(8)
-                Difficulty.MEDIUM -> Lives(6)
-                Difficulty.HARD -> Lives(4)
-            }
-
         fun forSecret(
             prompt: Prompt,
             difficulty: Difficulty,

--- a/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Lives.kt
+++ b/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/Lives.kt
@@ -1,5 +1,7 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
+import kotlin.math.roundToInt
+
 @JvmInline
 value class Lives(
     val remaining: Int,
@@ -13,11 +15,22 @@ value class Lives(
     fun isExhausted(): Boolean = remaining == 0
 
     companion object {
+        private const val PER_WORD_BASE = 3
+        private const val MIN_LIVES = 2
+
         fun initialFor(difficulty: Difficulty): Lives =
             when (difficulty) {
                 Difficulty.EASY -> Lives(8)
                 Difficulty.MEDIUM -> Lives(6)
                 Difficulty.HARD -> Lives(4)
             }
+
+        fun forSecret(
+            prompt: Prompt,
+            difficulty: Difficulty,
+        ): Lives {
+            val raw = (PER_WORD_BASE * prompt.words().size * difficulty.livesMultiplier).roundToInt()
+            return Lives(maxOf(MIN_LIVES, raw))
+        }
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -160,7 +160,7 @@ class ChallengeTest {
         val max = challenge.maxLives()
 
         // Then
-        assertEquals(Lives(6), max)
+        assertEquals(Lives(6), max) // round(3 * 2 * 1.0) = 6
     }
 
     @Test

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -160,7 +160,7 @@ class ChallengeTest {
         val max = challenge.maxLives()
 
         // Then
-        assertEquals(Lives(6), max) // round(3 * 2 * 1.0) = 6
+        assertEquals(Lives(6), max)
     }
 
     @Test

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
+import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
@@ -148,6 +149,18 @@ class ChallengeTest {
         assertEquals(challenge.version, updated.version)
         assertEquals(Picture.Pending, challenge.picture)
         assertNotSame(challenge, updated)
+    }
+
+    @Test
+    fun `maxLives derives from the challenge secret and difficulty`() {
+        // Given
+        val challenge = mediumChallenge()
+
+        // When
+        val max = challenge.maxLives()
+
+        // Then
+        assertEquals(Lives(6), max)
     }
 
     @Test

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
@@ -1,5 +1,6 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -47,15 +48,30 @@ class LivesTest {
     }
 
     @Test
-    fun `initial lives are granted per difficulty`() {
+    fun `forSecret scales lives by word count and difficulty`() {
+        // Given
+        val twoWordPrompt = "hello world".asPrompt()
+
         // When
-        val easy = Lives.initialFor(Difficulty.EASY)
-        val medium = Lives.initialFor(Difficulty.MEDIUM)
-        val hard = Lives.initialFor(Difficulty.HARD)
+        val easy = Lives.forSecret(twoWordPrompt, Difficulty.EASY)
+        val medium = Lives.forSecret(twoWordPrompt, Difficulty.MEDIUM)
+        val hard = Lives.forSecret(twoWordPrompt, Difficulty.HARD)
 
         // Then
-        assertEquals(Lives(8), easy)
+        assertEquals(Lives(9), easy)
         assertEquals(Lives(6), medium)
         assertEquals(Lives(4), hard)
+    }
+
+    @Test
+    fun `forSecret floors at MIN_LIVES for very short secrets`() {
+        // Given
+        val oneWordPrompt = "x".asPrompt()
+
+        // When
+        val result = Lives.forSecret(oneWordPrompt, Difficulty.HARD)
+
+        // Then
+        assertEquals(Lives(2), result)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
@@ -72,6 +72,6 @@ class LivesTest {
         val result = Lives.forSecret(oneWordPrompt, Difficulty.HARD)
 
         // Then
-        assertEquals(Lives(2), result)
+        assertEquals(Lives(2), result) // round(3 * 1 * 0.7) = 2 >= MIN_LIVES
     }
 }

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
@@ -10,20 +10,20 @@ import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 
 object Challenges {
     fun easyChallenge(
-        lives: Lives = Lives.initialFor(Difficulty.EASY),
         prompt: Prompt = "hello world".asPrompt(),
+        lives: Lives = Lives.forSecret(prompt, Difficulty.EASY),
         picture: Picture = Picture.Pending,
     ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.EASY)
 
     fun mediumChallenge(
-        lives: Lives = Lives.initialFor(Difficulty.MEDIUM),
         prompt: Prompt = "hello world".asPrompt(),
+        lives: Lives = Lives.forSecret(prompt, Difficulty.MEDIUM),
         picture: Picture = Picture.Pending,
     ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.MEDIUM)
 
     fun hardChallenge(
-        lives: Lives = Lives.initialFor(Difficulty.HARD),
         prompt: Prompt = "hello world".asPrompt(),
+        lives: Lives = Lives.forSecret(prompt, Difficulty.HARD),
         picture: Picture = Picture.Pending,
     ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.HARD)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,90 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      BTM_PERSISTENCE: sqlite
+      BTM_DB_PATH: /data/beat-the-machine.db
+      BTM_PROMPT_PROVIDER: ${BTM_PROMPT_PROVIDER:-ollama}
+      # SPRING_AI_MODEL_CHAT must match BTM_PROMPT_PROVIDER: it activates
+      # the Spring AI chat auto-config that supplies the ChatClient.Builder
+      # the ollama/openai PromptSource beans need. Mismatch = boot failure.
+      SPRING_AI_MODEL_CHAT: ${SPRING_AI_MODEL_CHAT:-ollama}
+      SPRING_AI_OLLAMA_BASE_URL: ${SPRING_AI_OLLAMA_BASE_URL:-http://ollama:11434}
+      SPRING_AI_OLLAMA_CHAT_OPTIONS_MODEL: ${OLLAMA_MODEL:-llama3.2}
+      BTM_IMAGE_PROVIDER: ${BTM_IMAGE_PROVIDER:-seed}
+      # For BTM_IMAGE_PROVIDER=paid also set SPRING_AI_MODEL_IMAGE=openai
+      # and SPRING_AI_OPENAI_API_KEY. local-sd needs no Spring AI (pure
+      # WebClient), so SPRING_AI_MODEL_IMAGE stays unset (none).
+      BTM_IMAGE_LOCAL_SD_BASE_URL: ${BTM_IMAGE_LOCAL_SD_BASE_URL:-http://stable-diffusion:7860}
+    volumes:
+      - app-data:/data
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+
+  # Linux + NVIDIA GPU — run with: docker compose --profile sd up
+  stable-diffusion:
+    image: universonic/stable-diffusion-webui:latest
+    profiles: ["sd"]
+    ports:
+      - "7860:7860"
+    command: ["--api", "--listen"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: ["gpu"]
+    volumes:
+      - sd-data:/data
+
+  # CPU-only Stable Diffusion for hosts WITHOUT an NVIDIA GPU (incl. Apple
+  # Silicon, where Docker cannot use the Mac GPU). Generation is slow
+  # (minutes per image); meant to feed the background pre-seed pool, not
+  # interactive play. The `stable-diffusion` network alias means the app's
+  # default BTM_IMAGE_LOCAL_SD_BASE_URL works unchanged.
+  #
+  # First run downloads a Stable Diffusion 1.5 checkpoint (~4 GB).
+  # Not runtime-verified in this repo; adjust image/flags to your chosen
+  # A1111 build. Alternative: AbdBarho/stable-diffusion-webui-docker
+  # (--profile auto-cpu).
+  #
+  # Run with: docker compose --profile sd-cpu up
+  stable-diffusion-cpu:
+    image: universonic/stable-diffusion-webui:latest
+    # Apple Silicon: no arm64 image; force amd64 emulation (even slower):
+    # platform: linux/amd64
+    profiles: ["sd-cpu"]
+    ports:
+      - "7860:7860"
+    command:
+      - "--api"
+      - "--listen"
+      - "--skip-torch-cuda-test"
+      - "--use-cpu"
+      - "all"
+      - "--no-half"
+      - "--precision"
+      - "full"
+    networks:
+      default:
+        aliases:
+          - stable-diffusion
+    volumes:
+      - sd-cpu-data:/data
+
+volumes:
+  app-data:
+  ollama-data:
+  sd-data:
+  sd-cpu-data:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ openapi-generator = "7.23.0"
 node = "22.12.0"
 spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
-testballoon = "1.0.1-K2.4.0"
 openapiContracts = "0.1.0"
 mockk = "1.14.11"
 springmockk = "5.0.1"
@@ -32,7 +31,6 @@ kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 
 # --- Explicitly versioned (not on the BOM, or used where the BOM is absent) ---
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-testballoon-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -76,4 +74,3 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 openapi-contracts = { id = "com.yonatankarp.openapi.contracts", version.ref = "openapiContracts" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
-testballoon = { id = "de.infix.testBalloon", version.ref = "testballoon" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ openapi-generator = "7.23.0"
 node = "22.12.0"
 spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
+testballoon = "1.0.1-K2.4.0"
 openapiContracts = "0.1.0"
 mockk = "1.14.11"
 springmockk = "5.0.1"
@@ -12,6 +13,8 @@ jvm = "25"
 # Matches the version managed by Spring Boot 4.1.0's BOM (kotlinx-coroutines-bom).
 # Pinned here for the application module, which has no Spring dependency management.
 kotlinx-coroutines = "1.11.0"
+mockwebserver = "4.12.0"
+spring-ai = "2.0.0"
 
 [libraries]
 # --- Versions managed by Spring Boot's BOM (no version declared here) ---
@@ -29,10 +32,15 @@ kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 
 # --- Explicitly versioned (not on the BOM, or used where the BOM is absent) ---
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+testballoon-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
+spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai" }
+spring-ai-starter-model-openai = { module = "org.springframework.ai:spring-ai-starter-model-openai" }
+spring-ai-starter-model-ollama = { module = "org.springframework.ai:spring-ai-starter-model-ollama" }
 
 [bundles]
 # Production Spring Boot starters used by the adapters module.
@@ -51,6 +59,7 @@ kotlinx-coroutines = [
 unit-test = [
     "kotlin-test",
     "mockk",
+    "mockwebserver",
 ]
 # Spring slice/integration testing plus the springmockk @MockkBean bridge.
 spring-boot-test = [
@@ -67,3 +76,4 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 openapi-contracts = { id = "com.yonatankarp.openapi.contracts", version.ref = "openapiContracts" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
+testballoon = { id = "de.infix.testBalloon", version.ref = "testballoon" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,11 @@ spring-boot-test = [
     "spring-boot-starter-webflux-test",
     "springmockk",
 ]
+# Spring AI model starters (versions resolved by the spring-ai-bom platform).
+spring-ai-starters = [
+    "spring-ai-starter-model-openai",
+    "spring-ai-starter-model-ollama",
+]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Local LLM + image generation (reworked onto current main)

Re-implemented on top of the updated `main`, in main's current conventions
(testFixtures DSL, comment-free production code, named constants,
`@ConditionalOnProperty` wiring) and readability-first.

### What it adds
- **Domain:** lives derived from the secret — `Lives.forSecret(prompt, difficulty)`
  (round(3 × wordCount × difficulty multiplier), floored), `Challenge.maxLives()`.
- **Generation:** `PictureStore` port + in-memory/SQLite (`picture` table), served at
  `GET /images/{id}` with a MIME allowlist. Image adapters deduped behind
  `ImageRendering` (`imageWebClient`, `renderedPicture {}` enforcing
  never-throw → `Picture.Failed`): `LocalStableDiffusionMachine` (Automatic1111) +
  `SpringAiImageMachine` (paid). `SpringAiPromptSource` (bands, retry, seed fallback)
  via a small `LlmText` seam over Spring AI `ChatClient`.
- **Wiring:** provider selection via `btm.prompt.provider` / `btm.image.provider`
  (default `seed`), `spring.ai.model.*=none` for keyless default boot, Spring AI 2.0.0.
- **Infra:** `compose.yaml` (app + Ollama; `sd` GPU profile; `sd-cpu` profile),
  `.dockerignore` (no `**/build`), README run docs + provider/env table, CSP tighten.

### Verification
- `./gradlew check` green; keyless production boot bootRun-verified
  (`/health`=200, `/`→302, no AI env).
- Default app runs with zero config (seed providers). Selecting a Spring AI provider
  requires the matching `SPRING_AI_MODEL_*` switch — documented in README + `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
