### PR TITLE
feat: serve challenges from a pre-seeded pool with background replenishment

### DIFF
--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
 import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
 import com.yonatankarp.beatthemachine.application.port.input.MakeGuess
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
 import com.yonatankarp.beatthemachine.application.port.output.Machine
@@ -13,13 +14,18 @@ import com.yonatankarp.beatthemachine.application.usecase.ForfeitChallengeUseCas
 import com.yonatankarp.beatthemachine.application.usecase.GetChallengeUseCase
 import com.yonatankarp.beatthemachine.application.usecase.MakeGuessUseCase
 import com.yonatankarp.beatthemachine.application.usecase.StartChallengeUseCase
+import com.yonatankarp.beatthemachine.output.ai.ChallengePoolReplenisher
+import com.yonatankarp.beatthemachine.output.ai.ChallengeTemplateSeeder
 import com.yonatankarp.beatthemachine.output.ai.PicturePregeneration
 import kotlinx.coroutines.launch
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
+@EnableScheduling
 class BeanConfig {
     @Bean
     fun pictureScope(): PictureScope = PictureScope()
@@ -34,6 +40,32 @@ class BeanConfig {
     ): PicturePregeneration = PicturePregeneration(machine, findChallengeById, storeChallenge, findPendingChallenges, pictureScope)
 
     @Bean
+    fun challengePoolReplenisher(
+        promptSource: PromptSource,
+        machine: Machine,
+        challengeTemplates: ChallengeTemplates,
+        pictureScope: PictureScope,
+        @Value("\${btm.pool.target:10}") target: Int,
+    ): ChallengePoolReplenisher = ChallengePoolReplenisher(promptSource, machine, challengeTemplates, pictureScope, target)
+
+    @Bean
+    fun challengeTemplateSeeder(challengeTemplates: ChallengeTemplates): ChallengeTemplateSeeder =
+        ChallengeTemplateSeeder(challengeTemplates)
+
+    @Bean
+    fun poolWarmUpRunner(
+        seeder: ChallengeTemplateSeeder,
+        replenisher: ChallengePoolReplenisher,
+        pictureScope: PictureScope,
+    ): ApplicationRunner =
+        ApplicationRunner {
+            pictureScope.launch {
+                seeder.seed()
+                replenisher.warmUp()
+            }
+        }
+
+    @Bean
     fun pendingPictureRetryRunner(
         picturePregeneration: PicturePregeneration,
         pictureScope: PictureScope,
@@ -44,10 +76,19 @@ class BeanConfig {
 
     @Bean
     fun startChallenge(
+        challengeTemplates: ChallengeTemplates,
         promptSource: PromptSource,
         storeChallenge: StoreChallenge,
         picturePregeneration: PicturePregeneration,
-    ): StartChallenge = StartChallengeUseCase(promptSource, storeChallenge, picturePregeneration::enqueue)
+        challengePoolReplenisher: ChallengePoolReplenisher,
+    ): StartChallenge =
+        StartChallengeUseCase(
+            challengeTemplates,
+            promptSource,
+            storeChallenge,
+            picturePregeneration::enqueue,
+            challengePoolReplenisher::replenish,
+        )
 
     @Bean
     fun makeGuess(

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/InMemoryPersistenceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/InMemoryPersistenceConfig.kt
@@ -1,11 +1,13 @@
 package com.yonatankarp.beatthemachine.config
 
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeStore
+import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeTemplates
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPendingChallenges
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPicture
@@ -39,4 +41,7 @@ class InMemoryPersistenceConfig {
 
     @Bean
     fun findPicture(storage: InMemoryPictureStorage): FindPicture = InMemoryFindPicture(storage)
+
+    @Bean
+    fun challengeTemplates(): ChallengeTemplates = InMemoryChallengeTemplates()
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/SqlitePersistenceConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/SqlitePersistenceConfig.kt
@@ -1,11 +1,13 @@
 package com.yonatankarp.beatthemachine.config
 
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.ChallengeRowMapper
+import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteChallengeTemplates
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteFindPendingChallenges
 import com.yonatankarp.beatthemachine.output.persistence.sqlite.SqliteFindPicture
@@ -45,4 +47,7 @@ class SqlitePersistenceConfig {
 
     @Bean
     fun findPicture(jdbcTemplate: JdbcTemplate): FindPicture = SqliteFindPicture(jdbcTemplate)
+
+    @Bean
+    fun challengeTemplates(jdbcTemplate: JdbcTemplate): ChallengeTemplates = SqliteChallengeTemplates(jdbcTemplate)
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengePoolReplenisher.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengePoolReplenisher.kt
@@ -1,0 +1,55 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class ChallengePoolReplenisher(
+    private val promptSource: PromptSource,
+    private val machine: Machine,
+    private val templates: ChallengeTemplates,
+    private val scope: CoroutineScope,
+    private val target: Int,
+    private val idFactory: () -> String = { UUID.randomUUID().toString() },
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val inFlight = ConcurrentHashMap.newKeySet<Difficulty>()
+
+    fun warmUp() = Difficulty.entries.forEach { replenish(it) }
+
+    fun replenish(difficulty: Difficulty) {
+        if (!inFlight.add(difficulty)) return
+        scope.launch {
+            try {
+                var deficit = target - (templates count difficulty)
+                while (deficit-- > 0) {
+                    val prompt = promptSource answer PromptSource.Query(difficulty)
+                    when (val picture = machine answer Machine.Query(prompt)) {
+                        is Picture.Ready -> {
+                            templates save ChallengeTemplate(idFactory(), difficulty, prompt, picture.url)
+                        }
+
+                        else -> {
+                            logger.warn("Skipping failed template generation for {}", difficulty)
+                        }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error("Pool replenish failed for {}", difficulty, e)
+            } finally {
+                inFlight.remove(difficulty)
+            }
+        }
+    }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengeTemplateSeeder.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengeTemplateSeeder.kt
@@ -1,0 +1,21 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import java.util.UUID
+
+class ChallengeTemplateSeeder(
+    private val templates: ChallengeTemplates,
+    private val idFactory: () -> String = { UUID.randomUUID().toString() },
+) {
+    suspend fun seed() {
+        Difficulty.entries.forEach { difficulty ->
+            if ((templates count difficulty) == 0) {
+                SEED.forEach { (prompt, url) ->
+                    templates save ChallengeTemplate(idFactory(), difficulty, prompt, url)
+                }
+            }
+        }
+    }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/PoolSweep.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/PoolSweep.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class PoolSweep(
+    private val replenisher: ChallengePoolReplenisher,
+) {
+    @Scheduled(fixedDelayString = "\${btm.pool.sweep-ms:60000}")
+    fun sweep() {
+        replenisher.warmUp()
+    }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeTemplates.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeTemplates.kt
@@ -1,0 +1,23 @@
+package com.yonatankarp.beatthemachine.output.persistence.inmemory
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.random.Random
+
+class InMemoryChallengeTemplates : ChallengeTemplates {
+    private val byId = ConcurrentHashMap<String, ChallengeTemplate>()
+
+    override suspend fun save(template: ChallengeTemplate): ChallengeTemplate {
+        byId[template.id] = template
+        return template
+    }
+
+    override suspend fun randomReady(difficulty: Difficulty): ChallengeTemplate? {
+        val matches = byId.values.filter { it.difficulty == difficulty }
+        return if (matches.isEmpty()) null else matches[Random.nextInt(matches.size)]
+    }
+
+    override suspend fun count(difficulty: Difficulty): Int = byId.values.count { it.difficulty == difficulty }
+}

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteChallengeTemplates.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteChallengeTemplates.kt
@@ -1,0 +1,51 @@
+package com.yonatankarp.beatthemachine.output.persistence.sqlite
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.springframework.jdbc.core.JdbcTemplate
+
+class SqliteChallengeTemplates(
+    private val jdbc: JdbcTemplate,
+) : ChallengeTemplates {
+    override suspend fun save(template: ChallengeTemplate): ChallengeTemplate =
+        withContext(Dispatchers.IO) {
+            jdbc.update(
+                "INSERT OR REPLACE INTO challenge_template (id, difficulty, prompt, picture_url) VALUES (?, ?, ?, ?)",
+                template.id,
+                template.difficulty.name,
+                template.prompt.text,
+                template.pictureUrl,
+            )
+            template
+        }
+
+    override suspend fun randomReady(difficulty: Difficulty): ChallengeTemplate? =
+        withContext(Dispatchers.IO) {
+            jdbc
+                .query(
+                    "SELECT id, difficulty, prompt, picture_url FROM challenge_template WHERE difficulty = ? ORDER BY RANDOM() LIMIT 1",
+                    { rs, _ ->
+                        ChallengeTemplate(
+                            rs.getString("id"),
+                            Difficulty.valueOf(rs.getString("difficulty")),
+                            Prompt(rs.getString("prompt")),
+                            rs.getString("picture_url"),
+                        )
+                    },
+                    difficulty.name,
+                ).firstOrNull()
+        }
+
+    override suspend fun count(difficulty: Difficulty): Int =
+        withContext(Dispatchers.IO) {
+            jdbc.queryForObject(
+                "SELECT COUNT(*) FROM challenge_template WHERE difficulty = ?",
+                Int::class.java,
+                difficulty.name,
+            ) ?: 0
+        }
+}

--- a/beat-the-machine-adapters/src/main/resources/application.yml
+++ b/beat-the-machine-adapters/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
 
 btm:
   persistence: sqlite
+  pool:
+    target: ${BTM_POOL_TARGET:10}
+    sweep-ms: ${BTM_POOL_SWEEP_MS:60000}
   prompt:
     provider: ${BTM_PROMPT_PROVIDER:seed}
   image:

--- a/beat-the-machine-adapters/src/main/resources/schema.sql
+++ b/beat-the-machine-adapters/src/main/resources/schema.sql
@@ -15,3 +15,10 @@ CREATE TABLE IF NOT EXISTS picture (
     bytes        BLOB NOT NULL,
     content_type TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS challenge_template (
+    id          TEXT PRIMARY KEY,
+    difficulty  TEXT NOT NULL,
+    prompt      TEXT NOT NULL,
+    picture_url TEXT NOT NULL
+);

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -1,6 +1,11 @@
 package com.yonatankarp.beatthemachine.input.web
 
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
+import com.yonatankarp.beatthemachine.domain.entity.Challenge
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Lives
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.testballoon.spring.SpringTestConfig
 import com.yonatankarp.testballoon.spring.springTest
@@ -38,6 +43,22 @@ val StartChallengeControllerSuite by testSuite {
                 .doesNotExist()
                 .jsonPath("$.secretPrompt")
                 .doesNotExist()
+        }
+
+        test("started challenge exposes a ready picture") {
+            val challenge =
+                Challenge.start(Prompt("red car"), Lives(6), Picture.Ready("/images/a"), Difficulty.EASY)
+            coEvery { startChallenge handle any() } returns challenge
+
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges?difficulty=EASY")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.picture.status")
+                .isEqualTo("READY")
         }
 
         test("invalid difficulty query param returns 422") {

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -59,6 +59,8 @@ val StartChallengeControllerSuite by testSuite {
                 .expectBody()
                 .jsonPath("$.picture.status")
                 .isEqualTo("READY")
+                .jsonPath("$.picture.url")
+                .isEqualTo("/images/a")
         }
 
         test("invalid difficulty query param returns 422") {

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengePoolReplenisherTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengePoolReplenisherTest.kt
@@ -1,0 +1,79 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
+import com.yonatankarp.beatthemachine.application.port.output.Machine
+import com.yonatankarp.beatthemachine.application.port.output.PromptSource
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeTemplates
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+
+val ChallengePoolReplenisherSuite by testSuite {
+    given("a replenisher with a working machine") {
+        whenever("replenishing a difficulty below target") {
+            then("it fills the difficulty up to target") {
+                val templates: ChallengeTemplates = InMemoryChallengeTemplates()
+                val promptSource = mockk<PromptSource>()
+                val machine = mockk<Machine>()
+                coEvery { promptSource answer PromptSource.Query(Difficulty.EASY) } returns Prompt("red car")
+                coEvery { machine answer any() } returns Picture.Ready("/images/x")
+                val replenisher =
+                    ChallengePoolReplenisher(promptSource, machine, templates, CoroutineScope(Dispatchers.Unconfined), target = 3) {
+                        "id-${templates.hashCode()}-${System.nanoTime()}"
+                    }
+
+                replenisher.replenish(Difficulty.EASY)
+
+                templates.count(Difficulty.EASY) shouldBe 3
+            }
+        }
+
+        whenever("replenishing a difficulty already at target") {
+            then("it does not over-fill") {
+                val templates: ChallengeTemplates = InMemoryChallengeTemplates()
+                val promptSource = mockk<PromptSource>()
+                val machine = mockk<Machine>()
+                coEvery { promptSource answer PromptSource.Query(Difficulty.MEDIUM) } returns Prompt("blue boat")
+                coEvery { machine answer any() } returns Picture.Ready("/images/y")
+                val replenisher =
+                    ChallengePoolReplenisher(promptSource, machine, templates, CoroutineScope(Dispatchers.Unconfined), target = 1) {
+                        "id-${templates.hashCode()}-${System.nanoTime()}"
+                    }
+
+                replenisher.replenish(Difficulty.MEDIUM)
+                replenisher.replenish(Difficulty.MEDIUM)
+
+                templates.count(Difficulty.MEDIUM) shouldBe 1
+            }
+        }
+    }
+
+    given("a replenisher whose machine fails") {
+        whenever("replenishing a difficulty") {
+            then("it does not store failed generations") {
+                val templates: ChallengeTemplates = InMemoryChallengeTemplates()
+                val promptSource = mockk<PromptSource>()
+                val machine = mockk<Machine>()
+                coEvery { promptSource answer PromptSource.Query(Difficulty.HARD) } returns Prompt("a b c")
+                coEvery { machine answer any() } returns Picture.Failed
+                val replenisher =
+                    ChallengePoolReplenisher(promptSource, machine, templates, CoroutineScope(Dispatchers.Unconfined), target = 2) {
+                        "id-${templates.hashCode()}-${System.nanoTime()}"
+                    }
+
+                replenisher.replenish(Difficulty.HARD)
+
+                templates.count(Difficulty.HARD) shouldBe 0
+            }
+        }
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengeTemplateSeederTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/ChallengeTemplateSeederTest.kt
@@ -1,0 +1,29 @@
+package com.yonatankarp.beatthemachine.output.ai
+
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeTemplates
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+
+val ChallengeTemplateSeederSuite by testSuite {
+    given("a seeder over an empty pool") {
+        whenever("seeding twice") {
+            then("it seeds every difficulty from SEED and is idempotent") {
+                val templates = InMemoryChallengeTemplates()
+                var n = 0
+                val seeder = ChallengeTemplateSeeder(templates) { "seed-${n++}" }
+
+                seeder.seed()
+                val easyAfterFirst = templates.count(Difficulty.EASY)
+                seeder.seed()
+
+                easyAfterFirst shouldBe SEED.size
+                templates.count(Difficulty.EASY) shouldBe SEED.size
+                templates.count(Difficulty.HARD) shouldBe SEED.size
+            }
+        }
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeTemplatesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeTemplatesTest.kt
@@ -1,0 +1,35 @@
+package com.yonatankarp.beatthemachine.output.persistence.inmemory
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+val InMemoryChallengeTemplatesSuite by testSuite {
+    given("an in-memory template pool") {
+        whenever("saving templates of different difficulties") {
+            then("count and randomReady are partitioned by difficulty") {
+                val templates = InMemoryChallengeTemplates()
+                templates.save(ChallengeTemplate("1", Difficulty.EASY, Prompt("red car"), "/images/a"))
+                templates.save(ChallengeTemplate("2", Difficulty.HARD, Prompt("a b c"), "/images/b"))
+                templates.count(Difficulty.EASY) shouldBe 1
+                templates.count(Difficulty.MEDIUM) shouldBe 0
+                templates.randomReady(Difficulty.EASY)!!.prompt shouldBe Prompt("red car")
+                templates.randomReady(Difficulty.MEDIUM).shouldBeNull()
+            }
+        }
+
+        whenever("several templates of one difficulty exist") {
+            then("randomReady only returns the requested difficulty") {
+                val templates = InMemoryChallengeTemplates()
+                repeat(5) { templates.save(ChallengeTemplate("h$it", Difficulty.HARD, Prompt("x y z"), "/images/$it")) }
+                repeat(20) { templates.randomReady(Difficulty.HARD)!!.difficulty shouldBe Difficulty.HARD }
+            }
+        }
+    }
+}

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteChallengeTemplatesIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteChallengeTemplatesIT.kt
@@ -1,0 +1,34 @@
+package com.yonatankarp.beatthemachine.output.persistence.sqlite
+
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+val SqliteChallengeTemplatesITSuite by testSuite {
+    given("a SQLite template pool") {
+        whenever("saving templates and reloading them") {
+            then("count and randomReady round-trip by difficulty") {
+                val templates = SqliteChallengeTemplates(newSqliteJdbc())
+                templates.save(ChallengeTemplate("1", Difficulty.EASY, Prompt("red car"), "/images/a"))
+                templates.save(ChallengeTemplate("2", Difficulty.EASY, Prompt("blue boat"), "/images/b"))
+                templates.save(ChallengeTemplate("3", Difficulty.HARD, Prompt("a b c"), "/images/c"))
+                templates.count(Difficulty.EASY) shouldBe 2
+                templates.count(Difficulty.HARD) shouldBe 1
+                templates.randomReady(Difficulty.HARD)!!.difficulty shouldBe Difficulty.HARD
+            }
+        }
+
+        whenever("a difficulty has no templates") {
+            then("randomReady returns null") {
+                val templates = SqliteChallengeTemplates(newSqliteJdbc())
+                templates.randomReady(Difficulty.MEDIUM).shouldBeNull()
+            }
+        }
+    }
+}

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/ChallengeTemplates.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/ChallengeTemplates.kt
@@ -1,0 +1,19 @@
+package com.yonatankarp.beatthemachine.application.port.output
+
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+
+data class ChallengeTemplate(
+    val id: String,
+    val difficulty: Difficulty,
+    val prompt: Prompt,
+    val pictureUrl: String,
+)
+
+interface ChallengeTemplates {
+    suspend infix fun save(template: ChallengeTemplate): ChallengeTemplate
+
+    suspend infix fun randomReady(difficulty: Difficulty): ChallengeTemplate?
+
+    suspend infix fun count(difficulty: Difficulty): Int
+}

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCase.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCase.kt
@@ -1,22 +1,40 @@
 package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 
 class StartChallengeUseCase(
+    private val challengeTemplates: ChallengeTemplates,
     private val promptSource: PromptSource,
     private val storeChallenge: StoreChallenge,
     private val enqueuePicture: (ChallengeId) -> Unit,
+    private val replenish: (Difficulty) -> Unit,
 ) : StartChallenge {
     override suspend fun handle(command: StartChallenge.Command): Challenge {
-        val prompt = promptSource answer PromptSource.Query(command.difficulty)
-        val challenge = Challenge.start(prompt, Lives.forSecret(prompt, command.difficulty), difficulty = command.difficulty)
+        val difficulty = command.difficulty
+        val template = challengeTemplates.randomReady(difficulty)
+        val challenge =
+            if (template != null) {
+                Challenge.start(
+                    template.prompt,
+                    Lives.forSecret(template.prompt, difficulty),
+                    Picture.Ready(template.pictureUrl),
+                    difficulty,
+                )
+            } else {
+                val prompt = promptSource answer PromptSource.Query(difficulty)
+                Challenge.start(prompt, Lives.forSecret(prompt, difficulty), difficulty = difficulty)
+            }
         val persisted = storeChallenge handle StoreChallenge.Command(challenge)
-        enqueuePicture(persisted.id)
+        if (template == null) enqueuePicture(persisted.id)
+        replenish(difficulty)
         return persisted
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/ChallengeTemplateTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/ChallengeTemplateTest.kt
@@ -1,0 +1,22 @@
+package com.yonatankarp.beatthemachine.application.port.output
+
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+
+val ChallengeTemplateSuite by testSuite {
+    given("a challenge template") {
+        whenever("constructed with a difficulty, prompt and picture url") {
+            then("it carries the difficulty, prompt and picture url") {
+                val t = ChallengeTemplate("id-1", Difficulty.EASY, Prompt("red car"), "/images/abc")
+                t.difficulty shouldBe Difficulty.EASY
+                t.prompt shouldBe Prompt("red car")
+                t.pictureUrl shouldBe "/images/abc"
+            }
+        }
+    }
+}

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -1,50 +1,67 @@
 package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplate
+import com.yonatankarp.beatthemachine.application.port.output.ChallengeTemplates
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import com.yonatankarp.beatthemachine.test.dsl.given
 import com.yonatankarp.beatthemachine.test.dsl.then
 import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 
 val StartChallengeUseSuite by testSuite {
-    val fakePrompt = "hello world".asPrompt()
-    val prompts = mockk<PromptSource>().also { coEvery { it answer any() } returns fakePrompt }
-
-    given("a prompt source and store") {
-        whenever("starting a medium challenge") {
-            then("a pending challenge is created and picture generation is enqueued") {
+    given("a ready template in the pool") {
+        whenever("starting a challenge") {
+            then("it serves the template instantly without enqueuing a picture") {
+                val templates = mockk<ChallengeTemplates>()
+                val promptSource = mockk<PromptSource>()
                 val store = FakeChallengeStore()
                 val enqueued = mutableListOf<ChallengeId>()
-                val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
-                val challenge = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
-                challenge.picture shouldBe Picture.Pending
-                challenge.status shouldBe ChallengeStatus.IN_PROGRESS
-                enqueued shouldBe listOf(challenge.id)
+                val replenished = mutableListOf<Difficulty>()
+                coEvery { templates.randomReady(Difficulty.EASY) } returns
+                    ChallengeTemplate("t1", Difficulty.EASY, Prompt("red car"), "/images/a")
+                val startChallenge =
+                    StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
+
+                val challenge = startChallenge handle StartChallenge.Command(Difficulty.EASY)
+
+                challenge.picture shouldBe Picture.Ready("/images/a")
+                challenge.lives shouldBe Lives.forSecret(Prompt("red car"), Difficulty.EASY)
+                enqueued.shouldBeEmpty()
+                replenished shouldBe listOf(Difficulty.EASY)
                 store.byId.containsKey(challenge.id).shouldBeTrue()
             }
         }
+    }
 
-        whenever("starting challenges of each difficulty") {
-            then("the starting lives scale with difficulty") {
+    given("an empty pool") {
+        whenever("starting a challenge") {
+            then("it falls back to on-demand generation") {
+                val templates = mockk<ChallengeTemplates>()
+                val promptSource = mockk<PromptSource>()
                 val store = FakeChallengeStore()
-                val startChallenge = StartChallengeUseCase(prompts, store) {}
-                val easy = startChallenge handle StartChallenge.Command(Difficulty.EASY)
-                val medium = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
-                val hard = startChallenge handle StartChallenge.Command(Difficulty.HARD)
-                easy.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.EASY).remaining
-                medium.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining
-                hard.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.HARD).remaining
+                val enqueued = mutableListOf<ChallengeId>()
+                val replenished = mutableListOf<Difficulty>()
+                coEvery { templates.randomReady(Difficulty.HARD) } returns null
+                coEvery { promptSource answer PromptSource.Query(Difficulty.HARD) } returns Prompt("a b c")
+                val startChallenge =
+                    StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
+
+                val challenge = startChallenge handle StartChallenge.Command(Difficulty.HARD)
+
+                challenge.picture shouldBe Picture.Pending
+                enqueued shouldBe listOf(challenge.id)
+                replenished shouldBe listOf(Difficulty.HARD)
             }
         }
     }


### PR DESCRIPTION
Serves challenges from a pre-generated template pool for an instant READY picture, falling back to on-demand generation when the pool for a difficulty is empty. A background producer keeps the pool stocked.

## Changes

- `ChallengeTemplate` + `ChallengeTemplates` port (`save` / `randomReady` / `count`), with in-memory and SQLite (`challenge_template` table) implementations.
- `StartChallengeUseCase` tries `randomReady(difficulty)` first: serves a `Picture.Ready` challenge instantly when a template exists, otherwise generates a prompt with `Picture.Pending` and enqueues picture generation. Either path triggers a pool top-up.
- `ChallengePoolReplenisher` (coroutine producer, per-difficulty in-flight guard, fills to a configurable target), `ChallengeTemplateSeeder` (idempotent cold-start from curated SEED data), and a scheduled `PoolSweep`.
- Spring wiring plus `btm.pool.target` and `btm.pool.sweep-ms` config.

## Follow-ups (separate PRs)

- The pool fills to a fixed target and templates are reused, so it is effectively static after seeding. The intended "regenerate once a player has completed over 70% of the available templates" trigger needs a user/session identity the domain does not have yet.
- Refactor the new test suites so the given/when steps sit in their own scopes instead of inside `then` (blocked on a suspend-capable DSL change).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added challenge template pooling with automatic pre-seeding and background replenishment.
  * Starting a challenge can now use an available “ready” template for instant results; otherwise it falls back to on-demand generation and triggers replenishment.
  * Enabled scheduled pool sweeping to keep templates stocked.

* **Data & Persistence**
  * Added challenge template persistence in both in-memory and SQLite (`challenge_template` table).

* **Tests**
  * Added/updated test suites for template seeding, pool replenishment, and in-memory/SQLite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
