### PR TITLE
docs(roadmap): scope image blob lifecycle / retention

### DIFF
--- a/docs/roadmap/02-image-blob-lifecycle.md
+++ b/docs/roadmap/02-image-blob-lifecycle.md
@@ -1,0 +1,33 @@
+# Image blob lifecycle (bound DB growth)
+
+Status: draft / scope only — implementation TBD.
+Builds on: the pre-seed pool (01).
+
+## Problem
+
+Generated PNGs are stored as blobs in the SQLite `picture` table
+(see PR #18). A continuously-growing pool means blobs accumulate
+forever, so the database grows unbounded.
+
+## Goal
+
+Keep storage bounded without losing in-use images.
+
+## Scope
+
+- Decide a retention policy. Options:
+  - Cap the pool per difficulty (producer stops at N ready
+    templates); bounded by construction.
+  - Evict orphaned pictures: blobs not referenced by any live
+    challenge or pool template.
+  - Age-based eviction for least-recently-served templates.
+- A cleanup pass (scheduled, or on producer top-up) that deletes
+  unreferenced rows from `picture`.
+- Ensure deletion never removes a blob a live challenge still points
+  at (the picture URL is `/images/{id}`).
+- `VACUUM` consideration for SQLite to reclaim space after deletes.
+
+## Acceptance
+
+- DB size stabilises under sustained play + replenishment.
+- No live challenge ever 404s on its `/images/{id}` due to cleanup.


### PR DESCRIPTION
P1: bound SQLite picture-table growth from the pool via a retention
policy + orphan cleanup, without 404-ing live challenges.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>