### PR TITLE
docs(roadmap): scope generation observability

### DIFF
--- a/docs/roadmap/03-generation-observability.md
+++ b/docs/roadmap/03-generation-observability.md
@@ -1,0 +1,33 @@
+# Generation observability
+
+Status: draft / scope only — implementation TBD.
+Builds on: the pre-seed pool (01).
+
+## Problem
+
+Generation runs in the background and can fail silently (a flaky
+local SD, a bad LLM phrase, an exhausted pool). Today there is no way
+to see whether the pool is filling or starving.
+
+## Goal
+
+Make the producer/pool observable so operators can tell it is
+working and diagnose when it is not.
+
+## Scope
+
+- Metrics (Micrometer via the existing actuator):
+  - ready pool depth per difficulty (gauge),
+  - generations attempted / succeeded / failed (counters),
+  - generation latency (timer),
+  - on-demand fallback count (signals the pool is starving).
+- Structured logs already exist for failures; ensure they carry the
+  prompt/difficulty and outcome.
+- A lightweight read-only status surface (actuator endpoint or a
+  small JSON route) showing pool depth and recent generation
+  outcomes.
+
+## Acceptance
+
+- Pool depth and generation success/failure are visible at runtime.
+- A starving pool (fallbacks rising, depth at zero) is observable.


### PR DESCRIPTION
P1: pool-depth gauge + generation success/fail/latency metrics and a
read-only status surface so a starving pool is visible.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>