### PR TITLE
refactor: strip non-essential comments and apply Given/When/Then to tests

### DIFF
--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/BeanConfig.kt
@@ -47,7 +47,6 @@ class BeanConfig {
         pictureScope: PictureScope,
     ): ApplicationRunner =
         ApplicationRunner {
-            // Launch the retry sweep into the picture scope; the boot thread must not block.
             pictureScope.launch { picturePregeneration.retryPending() }
         }
 

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PictureScope.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/config/PictureScope.kt
@@ -7,23 +7,6 @@ import kotlinx.coroutines.cancel
 import org.springframework.beans.factory.DisposableBean
 import kotlin.coroutines.CoroutineContext
 
-/**
- * Application-wide scope for fire-and-forget picture generation.
- *
- * Replaces the old `core 2 / max 4` thread pool with structured concurrency:
- *  - a [SupervisorJob] so one failed generation never cancels its siblings or the scope,
- *  - [Dispatchers.IO] limited to [PICTURE_PARALLELISM] threads, bounding how many picture
- *    coroutines run on this scope's dispatcher at once.
- *
- * Note this caps only time spent *on this dispatcher*: each picture coroutine still hops to
- * the shared (unbounded) `Dispatchers.IO` pool inside the JDBC adapters' `withContext`, so
- * concurrent SQL statements are not limited to [PICTURE_PARALLELISM] here — the connection
- * pool (Hikari) is the real database-concurrency limiter. Backlog size is bounded separately
- * by the admission semaphore in [com.yonatankarp.beatthemachine.output.ai.PicturePregeneration].
- *
- * Cancelled on context shutdown via [DisposableBean], so in-flight generations are
- * cancelled and no coroutine outlives the application.
- */
 class PictureScope :
     CoroutineScope,
     DisposableBean {
@@ -35,7 +18,6 @@ class PictureScope :
     }
 
     companion object {
-        /** Matches the former thread pool's max parallelism. */
         const val PICTURE_PARALLELISM = 4
     }
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/ApiExceptionHandler.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/ApiExceptionHandler.kt
@@ -13,11 +13,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.bind.support.WebExchangeBindException
 import org.springframework.web.server.ServerWebInputException
 
-/**
- * Maps domain/application failures to HTTP status codes. Messages are fixed,
- * non-reflective strings: client input is never echoed back, so a malformed id or
- * a future invariant message can never leak through the error channel.
- */
 @RestControllerAdvice
 class ApiExceptionHandler {
     @ExceptionHandler(ChallengeNotFound::class)
@@ -36,8 +31,6 @@ class ApiExceptionHandler {
     fun handleInvalidGuess(ex: InvalidGuess): ResponseEntity<ErrorResponse> =
         ResponseEntity.status(HttpStatusCode.valueOf(422)).body(ErrorResponse("invalid guess"))
 
-    // Bean-validation failures on the request body (`@Valid`) surface in WebFlux as
-    // WebExchangeBindException (the MVC MethodArgumentNotValidException equivalent).
     @ExceptionHandler(WebExchangeBindException::class)
     fun handleValidation(ex: WebExchangeBindException): ResponseEntity<ErrorResponse> =
         ResponseEntity.status(HttpStatusCode.valueOf(422)).body(ErrorResponse("invalid request body"))
@@ -46,10 +39,6 @@ class ApiExceptionHandler {
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ErrorResponse> =
         ResponseEntity.status(HttpStatusCode.valueOf(422)).body(ErrorResponse("invalid input"))
 
-    // Query-param conversion failures (e.g. a bad `difficulty` enum) and undeserializable
-    // request bodies surface in WebFlux as ServerWebInputException (the MVC
-    // MethodArgumentTypeMismatchException equivalent). WebExchangeBindException is a
-    // subtype handled above, so it is matched first by Spring's most-specific resolution.
     @ExceptionHandler(ServerWebInputException::class)
     fun handleInputError(ex: ServerWebInputException): ResponseEntity<ErrorResponse> =
         ResponseEntity.status(HttpStatusCode.valueOf(422)).body(ErrorResponse("invalid request parameter"))

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilter.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilter.kt
@@ -6,11 +6,6 @@ import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 
-// Adds defence-in-depth security headers to every response. The SPA is served
-// same-origin by this backend, so the policy is restrictive: scripts only from
-// self, the AI image host allowed over https (tighten to the concrete host once
-// image generation is wired), inline styles permitted for the motion runtime,
-// and framing denied.
 @Component
 class SecurityHeadersFilter : WebFilter {
     override fun filter(

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouter.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouter.kt
@@ -11,10 +11,6 @@ import org.springframework.web.reactive.function.server.buildAndAwait
 import org.springframework.web.reactive.function.server.coRouter
 import java.net.URI
 
-// Forwards SPA client-side routes under /app/** to the SPA entry point so deep
-// links resolve. Scoped to /app/** so it never shadows the /api hierarchy,
-// /actuator, or static resources. Also redirects GET / to /app/ so users
-// land on the SPA when they hit the root.
 @Configuration
 class SpaForwardingRouter {
     @Bean

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregeneration.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregeneration.kt
@@ -13,22 +13,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import org.slf4j.LoggerFactory
 
-/**
- * Drives the asynchronous picture pipeline. A freshly started challenge is
- * persisted with [Picture.Pending]; [enqueue] launches the work into [scope], which
- * loads the challenge, asks the [Machine] to generate the picture, and persists
- * the result onto the latest version of the aggregate. A generation failure is
- * recorded as [Picture.Failed] rather than left pending forever.
- *
- * [scope] is the application-wide picture scope: a [kotlinx.coroutines.SupervisorJob]
- * over a parallelism-bounded dispatcher, so one failed task never cancels its
- * siblings and the work is throttled to a fixed number of concurrent generations.
- *
- * [maxQueued] bounds admission: [enqueue] takes a permit non-blockingly and sheds the
- * request if none is free, so a burst of starts (against a slow, network-bound machine)
- * cannot accumulate unbounded coroutines. A shed picture stays [Picture.Pending] and is
- * recovered by [retryPending] on the next restart.
- */
 class PicturePregeneration(
     private val machine: Machine,
     private val findChallengeById: FindChallengeById,
@@ -41,7 +25,6 @@ class PicturePregeneration(
     private val admission = Semaphore(maxQueued)
 
     fun enqueue(id: ChallengeId) {
-        // Non-suspending admission: never block the calling (Netty event-loop) thread.
         if (!admission.tryAcquire()) {
             logger.warn("picture queue full; shedding {} — retryPending recovers it on restart", id)
             return
@@ -51,12 +34,11 @@ class PicturePregeneration(
                 runCatching { generate(id) }
                     .onFailure { logger.error("Unexpected failure generating picture for challenge {}", id, it) }
             } finally {
-                admission.release() // also runs on cancellation, so permits are never leaked
+                admission.release()
             }
         }
     }
 
-    /** Re-enqueues every challenge whose picture is still pending (retry-on-restart). */
     suspend fun retryPending() {
         findPendingChallenges().forEach { enqueue(it.id) }
     }
@@ -67,7 +49,7 @@ class PicturePregeneration(
                 val current = findChallengeById(id) ?: return
                 machine generate current.secretPrompt()
             } catch (e: CancellationException) {
-                throw e // never swallow cancellation: it must propagate to keep structured concurrency intact
+                throw e
             } catch (e: Exception) {
                 logger.warn("Picture generation failed for challenge {}", id, e)
                 Picture.Failed
@@ -75,24 +57,18 @@ class PicturePregeneration(
         persistPicture(id, picture)
     }
 
-    /**
-     * Writes only the picture, onto the latest persisted version. A concurrent
-     * guess can bump the version between generation and this write, so we reload
-     * and retry on conflict rather than clobbering newer game state or losing the
-     * picture to a swallowed [OptimisticLockConflict].
-     */
     private suspend fun persistPicture(
         id: ChallengeId,
         picture: Picture,
     ) {
         repeat(MAX_SAVE_ATTEMPTS) {
             val latest = findChallengeById(id) ?: return
-            if (latest.picture !is Picture.Pending) return // already resolved by another writer
+            if (latest.picture !is Picture.Pending) return
             try {
                 storeChallenge(latest.withPicture(picture))
                 return
             } catch (_: OptimisticLockConflict) {
-                // concurrent write bumped the version; reload and retry
+                logger.debug("Version conflict persisting picture for challenge {}; reloading and retrying", id)
             }
         }
         logger.warn("Gave up persisting picture for challenge {} after {} attempts", id, MAX_SAVE_ATTEMPTS)
@@ -100,10 +76,6 @@ class PicturePregeneration(
 
     private companion object {
         const val MAX_SAVE_ATTEMPTS = 3
-
-        // Matches the former ThreadPoolTaskExecutor queueCapacity (the bounded backlog
-        // that fed core 2 / max 4 worker threads). Beyond this, starts are shed rather
-        // than queued, bounding memory under a burst against a slow machine.
         const val DEFAULT_MAX_QUEUED = 50
     }
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSource.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSource.kt
@@ -5,11 +5,6 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import kotlin.random.Random
 
-/**
- * Returns a random prompt from the curated [SEED] set. Difficulty does not yet
- * influence selection (there is a single seed pool); the parameter is honoured by
- * the port contract for when a difficulty-aware source replaces this seed adapter.
- */
 class SeedPromptSource : PromptSource {
     override suspend fun next(difficulty: Difficulty): Prompt = SEED[Random.nextInt(SEED.size)].first
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeStore.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryChallengeStore.kt
@@ -5,12 +5,6 @@ import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
-/**
- * Shared in-memory state for the challenge persistence operations. Its single
- * responsibility is holding challenges in memory; the operation adapters
- * (store / find / find-pending) own the behaviour and share this state, mirroring
- * how the SQLite operations share a [org.springframework.jdbc.core.JdbcTemplate].
- */
 class InMemoryChallengeStore {
     val byId: ConcurrentMap<ChallengeId, Challenge> = ConcurrentHashMap()
 }

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallenge.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallenge.kt
@@ -8,9 +8,6 @@ class InMemoryStoreChallenge(
     private val store: InMemoryChallengeStore,
 ) : StoreChallenge {
     override suspend fun invoke(challenge: Challenge): Challenge =
-        // Atomic check-then-act: compute runs the version check and the write under the
-        // map's per-key lock, so two concurrent coroutines on the same id cannot both pass
-        // the check and defeat optimistic locking (the picture pipeline races MakeGuess).
         store.byId.compute(challenge.id) { _, existing ->
             if (existing != null && existing.version != challenge.version) {
                 throw OptimisticLockConflict(challenge.id)

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRow.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRow.kt
@@ -1,14 +1,5 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
-/**
- * Plain data class used as the persistence mapping layer between the database and
- * the domain Challenge. The domain type is never annotated; this class is consumed
- * only by the [SqliteChallengeRepository] RowMapper.
- *
- * guesses are stored as a pipe-delimited (|) string. The pipe character is chosen
- * because it cannot appear in a valid guess word (guesses are single, non-blank
- * words; pipe is not a letter).
- */
 data class ChallengeRow(
     val id: String,
     val prompt: String,

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRowMapper.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRowMapper.kt
@@ -11,15 +11,6 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import org.springframework.jdbc.core.RowMapper
 import java.util.UUID
 
-/**
- * Translates between the [Challenge] aggregate, the [ChallengeRow] persistence
- * representation, and a JDBC [java.sql.ResultSet]. Single responsibility: the
- * domain <-> row mapping; it changes only when the row schema or representation
- * changes. The persistence operation adapters share one instance.
- *
- * guesses are stored as a pipe-delimited (|) string; the pipe cannot appear in a
- * valid single-word guess.
- */
 class ChallengeRowMapper {
     val rowMapper: RowMapper<ChallengeRow> =
         RowMapper { rs, _ ->

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallenge.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallenge.kt
@@ -37,8 +37,6 @@ class SqliteStoreChallenge(
                 )
 
             if (updated == 0) {
-                // Either the record does not yet exist (INSERT) or a concurrent
-                // write changed the version (conflict). Disambiguate by presence.
                 val exists =
                     jdbc.queryForObject(
                         "SELECT COUNT(*) FROM challenge WHERE id = ?",

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
@@ -9,16 +9,25 @@ import kotlin.test.assertTrue
 class PictureScopeTest {
     @Test
     fun `is active before shutdown`() {
+        // Given
         val scope = PictureScope()
-        assertTrue(scope.isActive)
+
+        // When
+        val active = scope.isActive
+
+        // Then
+        assertTrue(active)
     }
 
     @Test
     fun `destroy cancels the scope so no work outlives the application`() {
+        // Given
         val scope = PictureScope()
 
+        // When
         scope.destroy()
 
+        // Then
         assertFalse(scope.isActive)
         assertTrue(scope.coroutineContext.job.isCancelled)
     }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -18,60 +18,108 @@ class ChallengeApiMapperTest {
 
     @Test
     fun `maps a pending picture`() {
-        val r = challenge().toApiResponse()
-        assertEquals(PictureStatus.PENDING, r.picture.status)
-        assertEquals(null, r.picture.url)
+        // Given
+        val subject = challenge()
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(PictureStatus.PENDING, response.picture.status)
+        assertEquals(null, response.picture.url)
     }
 
     @Test
     fun `maps a ready picture with its url`() {
-        val r = challenge().withPicture(Picture.Ready("http://img/1.png")).toApiResponse()
-        assertEquals(PictureStatus.READY, r.picture.status)
-        assertEquals(URI.create("http://img/1.png"), r.picture.url)
+        // Given
+        val subject = challenge().withPicture(Picture.Ready("http://img/1.png"))
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(PictureStatus.READY, response.picture.status)
+        assertEquals(URI.create("http://img/1.png"), response.picture.url)
     }
 
     @Test
     fun `maps a failed picture`() {
-        val r = challenge().withPicture(Picture.Failed).toApiResponse()
-        assertEquals(PictureStatus.FAILED, r.picture.status)
-        assertEquals(null, r.picture.url)
+        // Given
+        val subject = challenge().withPicture(Picture.Failed)
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(PictureStatus.FAILED, response.picture.status)
+        assertEquals(null, response.picture.url)
     }
 
     @Test
     fun `degrades a ready picture with a malformed url to FAILED`() {
-        val r = challenge().withPicture(Picture.Ready("http:// bad url with spaces")).toApiResponse()
-        assertEquals(PictureStatus.FAILED, r.picture.status)
-        assertEquals(null, r.picture.url)
+        // Given
+        val subject = challenge().withPicture(Picture.Ready("http:// bad url with spaces"))
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(PictureStatus.FAILED, response.picture.status)
+        assertEquals(null, response.picture.url)
     }
 
     @Test
     fun `hides every word while the challenge is in progress`() {
-        val r = challenge().toApiResponse()
-        assertEquals(listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5)), r.maskedPrompt)
-        assertEquals(ChallengeStatus.IN_PROGRESS, r.status)
+        // Given
+        val subject = challenge()
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5)), response.maskedPrompt)
+        assertEquals(ChallengeStatus.IN_PROGRESS, response.status)
     }
 
     @Test
     fun `reveals the whole prompt once the challenge is lost`() {
-        val r = challenge().forfeit().toApiResponse()
-        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), r.maskedPrompt)
-        assertEquals("LOST", r.status.value)
+        // Given
+        val subject = challenge().forfeit()
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
+        assertEquals("LOST", response.status.value)
     }
 
     @Test
     fun `maps livesRemaining and the difficulty-derived maxLives`() {
-        val medium = challenge().toApiResponse()
+        // Given
+        val mediumChallenge = challenge()
+        val easyChallenge = Challenge.start(Prompt("hello world"), Lives(8), difficulty = DomainDifficulty.EASY)
+
+        // When
+        val medium = mediumChallenge.toApiResponse()
+        val easy = easyChallenge.toApiResponse()
+
+        // Then
         assertEquals(6, medium.livesRemaining)
         assertEquals(6, medium.maxLives)
-
-        val easy = Challenge.start(Prompt("hello world"), Lives(8), difficulty = DomainDifficulty.EASY).toApiResponse()
         assertEquals(8, easy.maxLives)
     }
 
     @Test
     fun `Difficulty toDomain maps each value to the same-named domain Difficulty`() {
-        assertEquals(DomainDifficulty.EASY, Difficulty.EASY.toDomain())
-        assertEquals(DomainDifficulty.MEDIUM, Difficulty.MEDIUM.toDomain())
-        assertEquals(DomainDifficulty.HARD, Difficulty.HARD.toDomain())
+        // When
+        val easy = Difficulty.EASY.toDomain()
+        val medium = Difficulty.MEDIUM.toDomain()
+        val hard = Difficulty.HARD.toDomain()
+
+        // Then
+        assertEquals(DomainDifficulty.EASY, easy)
+        assertEquals(DomainDifficulty.MEDIUM, medium)
+        assertEquals(DomainDifficulty.HARD, hard)
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -23,6 +23,7 @@ class ForfeitChallengeControllerTest(
     @Test
     fun `forfeit reveals the prompt and reports LOST`() {
         coEvery { forfeitChallenge(any()) } returns Challenge.start(Prompt("hello world"), Lives(6)).forfeit()
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/forfeit")
@@ -39,6 +40,7 @@ class ForfeitChallengeControllerTest(
     @Test
     fun `forfeit with concurrent modification returns 409`() {
         coEvery { forfeitChallenge(any()) } throws OptimisticLockConflict(ChallengeId.new())
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/forfeit")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -24,6 +24,7 @@ class GetChallengeControllerTest(
     fun `GET returns the challenge state`() {
         val challenge = Challenge.start(Prompt("hello world"), Lives(6))
         coEvery { getChallenge(any()) } returns challenge
+
         client
             .get()
             .uri("/api/challenges/${challenge.id.value}")
@@ -40,6 +41,7 @@ class GetChallengeControllerTest(
     @Test
     fun `GET an unknown challenge returns 404`() {
         coEvery { getChallenge(any()) } throws ChallengeNotFound(ChallengeId.new())
+
         client
             .get()
             .uri("/api/challenges/${ChallengeId.new().value}")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -29,6 +29,7 @@ class MakeGuessControllerTest(
     fun `a successful guess returns the updated masked prompt`() {
         val (afterHit, _) = Challenge.start(Prompt("hello world"), Lives(6)).makeGuess(Guess("hello"))
         coEvery { makeGuess(any(), any()) } returns (afterHit to GuessOutcome.HIT)
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/guesses")
@@ -47,6 +48,7 @@ class MakeGuessControllerTest(
     @Test
     fun `guessing an unknown challenge returns 404`() {
         coEvery { makeGuess(any(), any()) } throws ChallengeNotFound(ChallengeId.new())
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/guesses")
@@ -60,6 +62,7 @@ class MakeGuessControllerTest(
     @Test
     fun `guessing on an already-over challenge returns 409`() {
         coEvery { makeGuess(any(), any()) } throws ChallengeAlreadyOver(ChallengeId.new())
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/guesses")
@@ -73,6 +76,7 @@ class MakeGuessControllerTest(
     @Test
     fun `a domain-rejected guess returns 422`() {
         coEvery { makeGuess(any(), any()) } throws InvalidGuess("not a single word")
+
         client
             .post()
             .uri("/api/challenges/${ChallengeId.new().value}/guesses")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
@@ -14,8 +14,6 @@ class SpaForwardingRouterTest {
 
     @Test
     fun `the router is scoped to app and does not match other paths`() {
-        // A path outside /app/** must not be handled by this router (it falls through to a 404
-        // from the router with no matching route), proving it never shadows /api or /actuator.
         client
             .get()
             .uri("/api/challenges/anything")
@@ -44,8 +42,6 @@ class SpaForwardingRouterIntegrationTest(
 
     @Test
     fun `app deep links are served by the SPA entry point`() {
-        // With the SPA bundled, deep links under /app must return the SPA shell so client-side
-        // routing can take over. Verified against a real context where static/index.html is present.
         client
             .get()
             .uri("/app/some/deep/link")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -21,6 +21,7 @@ class StartChallengeControllerTest(
     @Test
     fun `POST creates a challenge and never leaks the prompt`() {
         coEvery { startChallenge(any()) } returns Challenge.start(Prompt("hello world"), Lives(6))
+
         client
             .post()
             .uri("/api/challenges")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -29,33 +29,40 @@ class PicturePregenerationTest {
     @Test
     fun `generation flips a pending picture to ready and persists it`() =
         runTest {
+            // Given
             val machine = Machine { Picture.Ready("http://img/1.png") }
             val c = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
 
+            // When
             pregeneration(machine, this).enqueue(c.id)
             advanceUntilIdle()
 
+            // Then
             assertEquals(Picture.Ready("http://img/1.png"), findById(c.id)?.picture)
         }
 
     @Test
     fun `a failing machine persists a failed picture`() =
         runTest {
+            // Given
             val machine = Machine { error("boom") }
             val c = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
 
+            // When
             pregeneration(machine, this).enqueue(c.id)
             advanceUntilIdle()
 
+            // Then
             assertEquals(Picture.Failed, findById(c.id)?.picture)
         }
 
     @Test
     fun `enqueue for an unknown challenge is a no-op`() =
         runTest {
+            // Given
             val machine = Machine { Picture.Ready("http://img/1.png") }
 
-            // Must not throw; nothing to persist.
+            // When
             pregeneration(machine, this).enqueue(ChallengeId.new())
             advanceUntilIdle()
         }
@@ -63,57 +70,62 @@ class PicturePregenerationTest {
     @Test
     fun `retryPending re-enqueues every challenge still awaiting a picture`() =
         runTest {
+            // Given
             val machine = Machine { Picture.Ready("http://img/retry.png") }
             val pending = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
             val done = storeChallenge(Challenge.start(Prompt("foo bar"), Lives(6)).withPicture(Picture.Ready("http://img/done.png")))
 
+            // When
             pregeneration(machine, this).retryPending()
             advanceUntilIdle()
 
+            // Then
             assertEquals(Picture.Ready("http://img/retry.png"), findById(pending.id)?.picture)
-            // an already-ready picture is left untouched
             assertEquals(Picture.Ready("http://img/done.png"), findById(done.id)?.picture)
         }
 
     @Test
     fun `a concurrent version bump is retried so the picture still persists`() =
         runTest {
+            // Given
             val seeded = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
 
-            // Simulate a guess landing exactly once between generation and the picture
-            // save: the first store sees a stale version and conflicts, the reload wins.
             var firstStore = true
             val racingStore =
                 StoreChallenge { challenge ->
                     if (firstStore && challenge.picture is Picture.Ready) {
                         firstStore = false
-                        storeChallenge(findById(challenge.id) ?: challenge) // competing write bumps the version
+                        storeChallenge(findById(challenge.id) ?: challenge)
                         throw OptimisticLockConflict(challenge.id)
                     }
                     storeChallenge(challenge)
                 }
             val machine = Machine { Picture.Ready("http://img/raced.png") }
 
+            // When
             pregeneration(machine, this, racingStore).enqueue(seeded.id)
             advanceUntilIdle()
 
+            // Then
             assertEquals(Picture.Ready("http://img/raced.png"), findById(seeded.id)?.picture)
         }
 
     @Test
     fun `enqueue sheds work once the admission bound is full`() =
         runTest {
+            // Given
             val machine = Machine { Picture.Ready("http://img/admitted.png") }
             val admitted = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
             val shed = storeChallenge(Challenge.start(Prompt("foo bar"), Lives(6)))
-
             val pregeneration = pregeneration(machine, this, maxQueued = 1)
-            pregeneration.enqueue(admitted.id) // takes the only permit; work queued, not yet run
-            pregeneration.enqueue(shed.id) // no permit free → shed, returns immediately
+
+            // When
+            pregeneration.enqueue(admitted.id)
+            pregeneration.enqueue(shed.id)
             advanceUntilIdle()
 
+            // Then
             assertEquals(Picture.Ready("http://img/admitted.png"), findById(admitted.id)?.picture)
-            // the shed challenge was never generated; it stays pending for retry-on-restart
             assertEquals(Picture.Pending, findById(shed.id)?.picture)
         }
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
@@ -12,13 +12,26 @@ class SeedMachineTest {
     @Test
     fun `returns the curated url for a known prompt`() =
         runTest {
+            // Given
             val (prompt, url) = SEED.first()
-            assertEquals(Picture.Ready(url), machine.generate(prompt))
+
+            // When
+            val result = machine.generate(prompt)
+
+            // Then
+            assertEquals(Picture.Ready(url), result)
         }
 
     @Test
     fun `returns Failed for an unknown prompt`() =
         runTest {
-            assertEquals(Picture.Failed, machine.generate(Prompt("a prompt that is not seeded")))
+            // Given
+            val prompt = Prompt("a prompt that is not seeded")
+
+            // When
+            val result = machine.generate(prompt)
+
+            // Then
+            assertEquals(Picture.Failed, result)
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
@@ -9,7 +9,10 @@ class SeedPromptSourceTest {
     @Test
     fun `returns a prompt from the curated seed set`() =
         runTest {
+            // Given
             val seedPrompts = SEED.map { it.first }.toSet()
+
+            // When / Then
             repeat(20) {
                 val prompt = SeedPromptSource().next(Difficulty.MEDIUM)
                 assertTrue(prompt in seedPrompts, "returned prompt must come from the curated SEED set")

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -10,20 +10,34 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class InMemoryFindChallengeByIdTest {
-    private val store = InMemoryChallengeStore()
-    private val storeChallenge = InMemoryStoreChallenge(store)
-    private val findChallengeById = InMemoryFindChallengeById(store)
-
     @Test
     fun `finds a stored challenge`() =
         runTest {
+            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findChallengeById = InMemoryFindChallengeById(store)
             val saved = storeChallenge(Challenge.start(Prompt("hello world"), Lives(3)))
-            assertEquals(saved.id, findChallengeById(saved.id)?.id)
+
+            // When
+            val found = findChallengeById(saved.id)
+
+            // Then
+            assertEquals(saved.id, found?.id)
         }
 
     @Test
     fun `returns null for an unknown id`() =
         runTest {
-            assertNull(findChallengeById(ChallengeId.new()))
+            // Given
+            val store = InMemoryChallengeStore()
+            val findChallengeById = InMemoryFindChallengeById(store)
+            val unknownId = ChallengeId.new()
+
+            // When
+            val found = findChallengeById(unknownId)
+
+            // Then
+            assertNull(found)
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -9,18 +9,21 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class InMemoryFindPendingChallengesTest {
-    private val store = InMemoryChallengeStore()
-    private val storeChallenge = InMemoryStoreChallenge(store)
-    private val findPendingChallenges = InMemoryFindPendingChallenges(store)
-
     @Test
     fun `returns only challenges whose picture is pending`() =
         runTest {
+            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findPendingChallenges = InMemoryFindPendingChallenges(store)
             val pendingA = storeChallenge(Challenge.start(Prompt("hello world"), Lives(3)))
             val pendingB = storeChallenge(Challenge.start(Prompt("red fox"), Lives(3)))
             storeChallenge(Challenge.start(Prompt("foo bar"), Lives(3)).withPicture(Picture.Ready("http://img/1.png")))
 
+            // When
             val ids = findPendingChallenges().map { it.id }.toSet()
+
+            // Then
             assertEquals(setOf(pendingA.id, pendingB.id), ids)
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -10,22 +10,31 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class InMemoryStoreChallengeTest {
-    private val store = InMemoryChallengeStore()
-    private val storeChallenge = InMemoryStoreChallenge(store)
-
     @Test
     fun `stores and bumps the version`() =
         runTest {
-            val saved = storeChallenge(Challenge.start(Prompt("hello world"), Lives(3)))
+            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val challenge = Challenge.start(Prompt("hello world"), Lives(3))
+
+            // When
+            val saved = storeChallenge(challenge)
+
+            // Then
             assertEquals(1L, saved.version)
         }
 
     @Test
     fun `rejects a stale version`() =
         runTest {
+            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
             val c = Challenge.start(Prompt("hello world"), Lives(3))
-            storeChallenge(c) // stored version becomes 1
-            // a second store carrying the original version 0 must conflict
+            storeChallenge(c)
+
+            // When / Then
             assertFailsWith<OptimisticLockConflict> { storeChallenge(c) }
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
@@ -26,10 +26,14 @@ class SqliteFindChallengeByIdIT {
     @Test
     fun `finds a stored challenge with its fields intact`() =
         runTest {
+            // Given
             val c = Challenge.start(Prompt("pixel art cat"), Lives(5))
             storeChallenge(c)
 
+            // When
             val found = findChallengeById(c.id)
+
+            // Then
             assertNotNull(found)
             assertEquals(c.id, found.id)
             assertEquals("pixel art cat", found.secretPrompt().text)
@@ -39,6 +43,13 @@ class SqliteFindChallengeByIdIT {
     @Test
     fun `returns null for an unknown id`() =
         runTest {
-            assertNull(findChallengeById(ChallengeId.new()))
+            // Given
+            val unknownId = ChallengeId.new()
+
+            // When
+            val found = findChallengeById(unknownId)
+
+            // Then
+            assertNull(found)
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
@@ -24,12 +24,16 @@ class SqliteFindPendingChallengesIT {
     @Test
     fun `returns only challenges whose picture is pending`() =
         runTest {
+            // Given
             val pendingA = storeChallenge(Challenge.start(Prompt("pending one"), Lives(2), picture = Picture.Pending))
             val pendingB = storeChallenge(Challenge.start(Prompt("pending two"), Lives(2), picture = Picture.Pending))
             storeChallenge(Challenge.start(Prompt("ready pic"), Lives(2), picture = Picture.Ready("https://example.com/img.png")))
             storeChallenge(Challenge.start(Prompt("failed pic"), Lives(2), picture = Picture.Failed))
 
+            // When
             val ids = findPendingChallenges().map { it.id }.toSet()
+
+            // Then
             assertEquals(setOf(pendingA.id, pendingB.id), ids)
         }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
@@ -28,31 +28,50 @@ class SqliteStoreChallengeIT {
     @Test
     fun `stores a fresh challenge and bumps the version`() =
         runTest {
-            val saved = storeChallenge(Challenge.start(Prompt("pixel art cat"), Lives(5)))
+            // Given
+            val challenge = Challenge.start(Prompt("pixel art cat"), Lives(5))
+
+            // When
+            val saved = storeChallenge(challenge)
+
+            // Then
             assertEquals(1L, saved.version)
         }
 
     @Test
     fun `allows sequential stores with updated versions`() =
         runTest {
-            val v1 = storeChallenge(Challenge.start(Prompt("sequential"), Lives(3)))
-            assertEquals(1L, v1.version)
+            // Given
+            val challenge = Challenge.start(Prompt("sequential"), Lives(3))
+
+            // When
+            val v1 = storeChallenge(challenge)
             val v2 = storeChallenge(v1)
+
+            // Then
+            assertEquals(1L, v1.version)
             assertEquals(2L, v2.version)
         }
 
     @Test
     fun `rejects a stale version on second store`() =
         runTest {
+            // Given
             val c = Challenge.start(Prompt("hello world"), Lives(3))
-            storeChallenge(c) // stored version becomes 1
+            storeChallenge(c)
+
+            // When / Then
             assertFailsWith<OptimisticLockConflict> { storeChallenge(c) }
         }
 
     @Test
     fun `persists all difficulty levels`() =
         runTest {
-            Difficulty.entries.forEach { diff ->
+            // Given
+            val difficulties = Difficulty.entries
+
+            // When / Then
+            difficulties.forEach { diff ->
                 val c = Challenge.start(Prompt("test prompt"), Lives(2), difficulty = diff)
                 storeChallenge(c)
                 val found = findChallengeById(c.id)
@@ -64,14 +83,17 @@ class SqliteStoreChallengeIT {
     @Test
     fun `persists picture states correctly`() =
         runTest {
+            // Given
             val pending = Challenge.start(Prompt("pending pic"), Lives(2), picture = Picture.Pending)
             val ready = Challenge.start(Prompt("ready pic"), Lives(2), picture = Picture.Ready("https://example.com/img.png"))
             val failed = Challenge.start(Prompt("failed pic"), Lives(2), picture = Picture.Failed)
 
+            // When
             storeChallenge(pending)
             storeChallenge(ready)
             storeChallenge(failed)
 
+            // Then
             assertEquals(Picture.Pending, findChallengeById(pending.id)?.picture)
             assertEquals(Picture.Ready("https://example.com/img.png"), findChallengeById(ready.id)?.picture)
             assertEquals(Picture.Failed, findChallengeById(failed.id)?.picture)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
@@ -3,12 +3,6 @@ package com.yonatankarp.beatthemachine.output.persistence.sqlite
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
-/**
- * Builds a JdbcTemplate over a fresh in-memory SQLite database with the schema
- * applied. SingleConnectionDataSource keeps one connection open for the test,
- * which is required for SQLite in-memory DBs (each new connection gets a fresh
- * empty database).
- */
 internal fun newSqliteJdbc(): JdbcTemplate {
     val ds = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
     ds.setDriverClassName("org.sqlite.JDBC")

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/FindChallengeById.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/FindChallengeById.kt
@@ -3,7 +3,6 @@ package com.yonatankarp.beatthemachine.application.port.output
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 
-/** Looks up a single challenge by its id, or `null` when none exists. */
 fun interface FindChallengeById {
     suspend operator fun invoke(id: ChallengeId): Challenge?
 }

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/FindPendingChallenges.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/FindPendingChallenges.kt
@@ -1,13 +1,7 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 
-/**
- * Returns every challenge whose picture is still [Picture.Pending], used by the
- * startup retry runner to re-enqueue picture generation for challenges that were
- * created but never had their picture produced.
- */
 fun interface FindPendingChallenges {
     suspend operator fun invoke(): List<Challenge>
 }

--- a/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoreChallenge.kt
+++ b/beat-the-machine-application/src/main/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoreChallenge.kt
@@ -1,16 +1,7 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
-import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 
-/**
- * Persists a challenge, returning the stored aggregate with its version bumped.
- *
- * Implementations MUST perform an optimistic-locking check: compare the in-hand
- * [Challenge.version] against the stored version and throw [OptimisticLockConflict]
- * on a mismatch. The adapter is the single writer that increments the version;
- * domain operations leave it untouched.
- */
 fun interface StoreChallenge {
     suspend operator fun invoke(challenge: Challenge): Challenge
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/FakeChallengeStore.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/FakeChallengeStore.kt
@@ -7,10 +7,6 @@ import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 
-/**
- * In-memory test double backing the three segregated storage ports with a single
- * shared map (mirroring why the real persistence adapter is one class).
- */
 class FakeChallengeStore :
     StoreChallenge,
     FindChallengeById,

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -19,9 +19,14 @@ class ForfeitChallengeUseCaseTest {
     @Test
     fun `forfeit loads the challenge, sets LOST, and persists it`() =
         runTest {
+            // Given
             val c = seed()
             val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+
+            // When
             val result = forfeitChallenge(c.id)
+
+            // Then
             assertEquals(ChallengeStatus.LOST, result.status)
             assertEquals(ChallengeStatus.LOST, store(c.id)?.status)
         }
@@ -29,9 +34,13 @@ class ForfeitChallengeUseCaseTest {
     @Test
     fun `an unknown challenge throws ChallengeNotFound`() =
         runTest {
+            // Given
             val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+            val unknownId = ChallengeId.new()
+
+            // When / Then
             assertFailsWith<ChallengeNotFound> {
-                forfeitChallenge(ChallengeId.new())
+                forfeitChallenge(unknownId)
             }
         }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -17,14 +17,23 @@ class GetChallengeUseCaseTest {
     @Test
     fun `returns a challenge that exists`() =
         runTest {
+            // Given
             val challenge = store(Challenge.start(Prompt("red fox"), Lives(6)))
 
-            assertEquals(challenge, getChallenge(challenge.id))
+            // When
+            val result = getChallenge(challenge.id)
+
+            // Then
+            assertEquals(challenge, result)
         }
 
     @Test
     fun `throws ChallengeNotFound for an unknown id`() =
         runTest {
-            assertFailsWith<ChallengeNotFound> { getChallenge(ChallengeId.new()) }
+            // Given
+            val unknownId = ChallengeId.new()
+
+            // When / Then
+            assertFailsWith<ChallengeNotFound> { getChallenge(unknownId) }
         }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -23,9 +23,15 @@ class MakeGuessUseCaseTest {
     @Test
     fun `a hit is persisted`() =
         runTest {
+            // Given
             val c = seed()
             val makeGuess = MakeGuessUseCase(store, store)
-            val (updated, outcome) = makeGuess(c.id, Guess("hello"))
+            val guess = Guess("hello")
+
+            // When
+            val (updated, outcome) = makeGuess(c.id, guess)
+
+            // Then
             assertEquals(GuessOutcome.HIT, outcome)
             assertEquals(MaskedToken.Revealed("hello"), updated.maskedPrompt().tokens[0])
             assertEquals(MaskedToken.Revealed("hello"), store(c.id)?.maskedPrompt()?.tokens?.get(0))
@@ -34,19 +40,29 @@ class MakeGuessUseCaseTest {
     @Test
     fun `an unknown challenge throws ChallengeNotFound`() =
         runTest {
+            // Given
             val makeGuess = MakeGuessUseCase(store, store)
+            val unknownId = ChallengeId.new()
+            val guess = Guess("hello")
+
+            // When / Then
             assertFailsWith<ChallengeNotFound> {
-                makeGuess(ChallengeId.new(), Guess("hello"))
+                makeGuess(unknownId, guess)
             }
         }
 
     @Test
     fun `an optimistic-lock conflict on store propagates`() =
         runTest {
+            // Given
             val c = seed()
             val conflicting = StoreChallenge { throw OptimisticLockConflict(it.id) }
+            val makeGuess = MakeGuessUseCase(store, conflicting)
+            val guess = Guess("hello")
+
+            // When / Then
             assertFailsWith<OptimisticLockConflict> {
-                MakeGuessUseCase(store, conflicting)(c.id, Guess("hello"))
+                makeGuess(c.id, guess)
             }
         }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -18,9 +18,14 @@ class StartChallengeUseCaseTest {
     @Test
     fun `starts a pending challenge and enqueues picture generation`() =
         runTest {
+            // Given
             val enqueued = mutableListOf<ChallengeId>()
             val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
+
+            // When
             val challenge = startChallenge(Difficulty.MEDIUM)
+
+            // Then
             assertEquals(Picture.Pending, challenge.picture)
             assertEquals(ChallengeStatus.IN_PROGRESS, challenge.status)
             assertEquals(listOf(challenge.id), enqueued)
@@ -30,9 +35,17 @@ class StartChallengeUseCaseTest {
     @Test
     fun `starting lives scale with difficulty`() =
         runTest {
+            // Given
             val startChallenge = StartChallengeUseCase(prompts, store) {}
-            assertEquals(8, startChallenge(Difficulty.EASY).lives.remaining)
-            assertEquals(6, startChallenge(Difficulty.MEDIUM).lives.remaining)
-            assertEquals(4, startChallenge(Difficulty.HARD).lives.remaining)
+
+            // When
+            val easy = startChallenge(Difficulty.EASY)
+            val medium = startChallenge(Difficulty.MEDIUM)
+            val hard = startChallenge(Difficulty.HARD)
+
+            // Then
+            assertEquals(8, easy.lives.remaining)
+            assertEquals(6, medium.lives.remaining)
+            assertEquals(4, hard.lives.remaining)
         }
 }

--- a/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/entity/Challenge.kt
+++ b/beat-the-machine-domain/src/main/kotlin/com/yonatankarp/beatthemachine/domain/entity/Challenge.kt
@@ -11,12 +11,6 @@ import com.yonatankarp.beatthemachine.domain.valueobject.MaskedPrompt
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 
-/**
- * The Challenge aggregate root. Immutable: every state transition returns a new
- * instance and leaves the receiver untouched. The version is never changed by a
- * domain operation; the persistence adapter is the single writer that increments
- * it on save.
- */
 class Challenge private constructor(
     val id: ChallengeId,
     private val prompt: Prompt,
@@ -56,14 +50,8 @@ class Challenge private constructor(
         return copy(status = ChallengeStatus.LOST)
     }
 
-    /**
-     * Returns a copy carrying the new picture. The version is left untouched (the
-     * persistence adapter increments it on save), so the async picture pipeline can
-     * apply this to the latest persisted aggregate without forcing a version bump.
-     */
     fun withPicture(picture: Picture): Challenge = copy(picture = picture)
 
-    // Exposed only to persistence mapping in the adapter module.
     fun secretPrompt(): Prompt = prompt
 
     private fun copy(

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -22,7 +22,14 @@ class ChallengeTest {
 
     @Test
     fun `a correct guess reveals the word and stays in progress`() {
-        val (updated, outcome) = newChallenge().makeGuess(Guess("hello"))
+        // Given
+        val challenge = newChallenge()
+        val guess = Guess("hello")
+
+        // When
+        val (updated, outcome) = challenge.makeGuess(guess)
+
+        // Then
         assertEquals(GuessOutcome.HIT, outcome)
         assertEquals(ChallengeStatus.IN_PROGRESS, updated.status)
         assertEquals(3, updated.lives.remaining)
@@ -30,72 +37,117 @@ class ChallengeTest {
 
     @Test
     fun `a wrong guess costs a life`() {
-        val (updated, outcome) = newChallenge().makeGuess(Guess("nope"))
+        // Given
+        val challenge = newChallenge()
+        val guess = Guess("nope")
+
+        // When
+        val (updated, outcome) = challenge.makeGuess(guess)
+
+        // Then
         assertEquals(GuessOutcome.MISS, outcome)
         assertEquals(2, updated.lives.remaining)
     }
 
     @Test
     fun `guessing every word beats the machine`() {
-        val (afterFirst, _) = newChallenge().makeGuess(Guess("hello"))
+        // Given
+        val challenge = newChallenge()
+        val (afterFirst, _) = challenge.makeGuess(Guess("hello"))
+
+        // When
         val (afterSecond, outcome) = afterFirst.makeGuess(Guess("world"))
+
+        // Then
         assertEquals(GuessOutcome.HIT, outcome)
         assertEquals(ChallengeStatus.BEATEN, afterSecond.status)
     }
 
     @Test
     fun `running out of lives loses the challenge`() {
-        val (updated, _) = newChallenge(lives = 1).makeGuess(Guess("nope"))
+        // Given
+        val challenge = newChallenge(lives = 1)
+        val guess = Guess("nope")
+
+        // When
+        val (updated, _) = challenge.makeGuess(guess)
+
+        // Then
         assertEquals(ChallengeStatus.LOST, updated.status)
     }
 
     @Test
     fun `a duplicate guess is a no-op and costs no life`() {
-        val (afterFirst, _) = newChallenge().makeGuess(Guess("nope"))
+        // Given
+        val challenge = newChallenge()
+        val (afterFirst, _) = challenge.makeGuess(Guess("nope"))
+
+        // When
         val (afterSecond, outcome) = afterFirst.makeGuess(Guess("Nope"))
+
+        // Then
         assertEquals(GuessOutcome.DUPLICATE, outcome)
         assertEquals(2, afterSecond.lives.remaining)
     }
 
     @Test
     fun `makeGuess does not mutate the receiver`() {
-        val original = newChallenge()
-        original.makeGuess(Guess("nope"))
-        assertEquals(3, original.lives.remaining)
-        assertTrue(original.guesses.isEmpty())
+        // Given
+        val challenge = newChallenge()
+        val guess = Guess("nope")
+
+        // When
+        challenge.makeGuess(guess)
+
+        // Then
+        assertEquals(3, challenge.lives.remaining)
+        assertTrue(challenge.guesses.isEmpty())
     }
 
     @Test
     fun `guessing after the challenge is over is rejected`() {
+        // Given
         val (lost, _) = newChallenge(lives = 1).makeGuess(Guess("nope"))
+
+        // When / Then
         assertFailsWith<ChallengeAlreadyOver> { lost.makeGuess(Guess("hello")) }
     }
 
     @Test
     fun `forfeit reveals the prompt and loses`() {
-        val forfeited = newChallenge().forfeit()
+        // Given
+        val challenge = newChallenge()
+
+        // When
+        val forfeited = challenge.forfeit()
+
+        // Then
         assertEquals(ChallengeStatus.LOST, forfeited.status)
         assertTrue(forfeited.maskedPrompt().tokens.all { it is MaskedToken.Revealed })
     }
 
     @Test
     fun `forfeit after the challenge is over is rejected`() {
+        // Given
         val forfeited = newChallenge().forfeit()
+
+        // When / Then
         assertFailsWith<ChallengeAlreadyOver> { forfeited.forfeit() }
     }
 
     @Test
     fun `withPicture returns an independent copy at the same version`() {
-        val c = newChallenge()
+        // Given
+        val challenge = newChallenge()
         val newPicture = Picture.Ready("https://example.com/img.png")
 
-        val updated = c.withPicture(newPicture)
+        // When
+        val updated = challenge.withPicture(newPicture)
 
+        // Then
         assertEquals(newPicture, updated.picture)
-        // Version is untouched: the persistence adapter increments it on save.
-        assertEquals(c.version, updated.version)
-        // original is unchanged
-        assertEquals(Picture.Pending, c.picture)
-        assertNotSame(c, updated)
+        assertEquals(challenge.version, updated.version)
+        assertEquals(Picture.Pending, challenge.picture)
+        assertNotSame(challenge, updated)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
@@ -8,16 +8,31 @@ import kotlin.test.assertFailsWith
 class GuessTest {
     @Test
     fun `rejects blank word`() {
-        assertFailsWith<InvalidGuess> { Guess("   ") }
+        // Given
+        val word = "   "
+
+        // When / Then
+        assertFailsWith<InvalidGuess> { Guess(word) }
     }
 
     @Test
     fun `rejects empty word`() {
-        assertFailsWith<InvalidGuess> { Guess("") }
+        // Given
+        val word = ""
+
+        // When / Then
+        assertFailsWith<InvalidGuess> { Guess(word) }
     }
 
     @Test
     fun `normalized trims and lowercases`() {
-        assertEquals("hello", Guess("Hello").normalized())
+        // Given
+        val guess = Guess("Hello")
+
+        // When
+        val normalized = guess.normalized()
+
+        // Then
+        assertEquals("hello", normalized)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
@@ -9,25 +9,53 @@ import kotlin.test.assertTrue
 class LivesTest {
     @Test
     fun `cannot be negative`() {
-        assertFailsWith<IllegalArgumentException> { Lives(-1) }
+        // Given
+        val count = -1
+
+        // When / Then
+        assertFailsWith<IllegalArgumentException> { Lives(count) }
     }
 
     @Test
     fun `lose decrements and floors at zero`() {
-        assertEquals(Lives(0), Lives(1).lose())
-        assertEquals(Lives(0), Lives(0).lose())
+        // Given
+        val oneLife = Lives(1)
+        val noLives = Lives(0)
+
+        // When
+        val afterLosingFromOne = oneLife.lose()
+        val afterLosingFromZero = noLives.lose()
+
+        // Then
+        assertEquals(Lives(0), afterLosingFromOne)
+        assertEquals(Lives(0), afterLosingFromZero)
     }
 
     @Test
     fun `is exhausted at zero`() {
-        assertTrue(Lives(0).isExhausted())
-        assertFalse(Lives(1).isExhausted())
+        // Given
+        val noLives = Lives(0)
+        val oneLife = Lives(1)
+
+        // When
+        val exhausted = noLives.isExhausted()
+        val notExhausted = oneLife.isExhausted()
+
+        // Then
+        assertTrue(exhausted)
+        assertFalse(notExhausted)
     }
 
     @Test
     fun `initial lives are granted per difficulty`() {
-        assertEquals(Lives(8), Lives.initialFor(Difficulty.EASY))
-        assertEquals(Lives(6), Lives.initialFor(Difficulty.MEDIUM))
-        assertEquals(Lives(4), Lives.initialFor(Difficulty.HARD))
+        // When
+        val easy = Lives.initialFor(Difficulty.EASY)
+        val medium = Lives.initialFor(Difficulty.MEDIUM)
+        val hard = Lives.initialFor(Difficulty.HARD)
+
+        // Then
+        assertEquals(Lives(8), easy)
+        assertEquals(Lives(6), medium)
+        assertEquals(Lives(4), hard)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
@@ -10,21 +10,42 @@ class MaskedPromptTest {
 
     @Test
     fun `hides every word when there are no guesses`() {
-        val masked = MaskedPrompt.of(prompt("hello world"), emptySet())
+        // Given
+        val secret = prompt("hello world")
+        val guesses = emptySet<Guess>()
+
+        // When
+        val masked = MaskedPrompt.of(secret, guesses)
+
+        // Then
         assertEquals(listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5)), masked.tokens)
         assertFalse(masked.isFullyRevealed())
     }
 
     @Test
     fun `reveals a matching word case-insensitively`() {
-        val masked = MaskedPrompt.of(prompt("Hello World"), setOf(Guess("hello")))
+        // Given
+        val secret = prompt("Hello World")
+        val guesses = setOf(Guess("hello"))
+
+        // When
+        val masked = MaskedPrompt.of(secret, guesses)
+
+        // Then
         assertEquals(MaskedToken.Revealed("Hello"), masked.tokens[0])
         assertEquals(MaskedToken.Hidden(5), masked.tokens[1])
     }
 
     @Test
     fun `reveals every occurrence of a repeated word`() {
-        val masked = MaskedPrompt.of(prompt("na na batman"), setOf(Guess("na")))
+        // Given
+        val secret = prompt("na na batman")
+        val guesses = setOf(Guess("na"))
+
+        // When
+        val masked = MaskedPrompt.of(secret, guesses)
+
+        // Then
         assertEquals(
             listOf(MaskedToken.Revealed("na"), MaskedToken.Revealed("na"), MaskedToken.Hidden(6)),
             masked.tokens,
@@ -33,14 +54,28 @@ class MaskedPromptTest {
 
     @Test
     fun `collapses arbitrary whitespace using one rule`() {
-        val masked = MaskedPrompt.of(prompt("hello\t \nworld"), setOf(Guess("world")))
+        // Given
+        val secret = prompt("hello\t \nworld")
+        val guesses = setOf(Guess("world"))
+
+        // When
+        val masked = MaskedPrompt.of(secret, guesses)
+
+        // Then
         assertEquals(2, masked.tokens.size)
         assertEquals(MaskedToken.Revealed("world"), masked.tokens[1])
     }
 
     @Test
     fun `is fully revealed when all words are guessed`() {
-        val masked = MaskedPrompt.of(prompt("hello world"), setOf(Guess("hello"), Guess("world")))
+        // Given
+        val secret = prompt("hello world")
+        val guesses = setOf(Guess("hello"), Guess("world"))
+
+        // When
+        val masked = MaskedPrompt.of(secret, guesses)
+
+        // Then
         assertTrue(masked.isFullyRevealed())
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PictureTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PictureTest.kt
@@ -7,18 +7,32 @@ import kotlin.test.assertIs
 class PictureTest {
     @Test
     fun `Pending is a Picture`() {
-        assertIs<Picture.Pending>(Picture.Pending)
+        // When
+        val picture = Picture.Pending
+
+        // Then
+        assertIs<Picture.Pending>(picture)
     }
 
     @Test
     fun `Ready carries url`() {
-        val pic = Picture.Ready("https://example.com/img.png")
+        // Given
+        val url = "https://example.com/img.png"
+
+        // When
+        val pic = Picture.Ready(url)
+
+        // Then
         assertIs<Picture.Ready>(pic)
         assertEquals("https://example.com/img.png", pic.url)
     }
 
     @Test
     fun `Failed is a Picture`() {
-        assertIs<Picture.Failed>(Picture.Failed)
+        // When
+        val picture = Picture.Failed
+
+        // Then
+        assertIs<Picture.Failed>(picture)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
@@ -7,21 +7,43 @@ import kotlin.test.assertFailsWith
 class PromptTest {
     @Test
     fun `splits on single space`() {
-        assertEquals(listOf("hello", "world"), Prompt("hello world").words())
+        // Given
+        val prompt = Prompt("hello world")
+
+        // When
+        val words = prompt.words()
+
+        // Then
+        assertEquals(listOf("hello", "world"), words)
     }
 
     @Test
     fun `splits on multiple whitespace characters`() {
-        assertEquals(listOf("a", "b", "c"), Prompt("a\t b\n c").words())
+        // Given
+        val prompt = Prompt("a\t b\n c")
+
+        // When
+        val words = prompt.words()
+
+        // Then
+        assertEquals(listOf("a", "b", "c"), words)
     }
 
     @Test
     fun `rejects blank text`() {
-        assertFailsWith<IllegalArgumentException> { Prompt("   ") }
+        // Given
+        val text = "   "
+
+        // When / Then
+        assertFailsWith<IllegalArgumentException> { Prompt(text) }
     }
 
     @Test
     fun `rejects empty text`() {
-        assertFailsWith<IllegalArgumentException> { Prompt("") }
+        // Given
+        val text = ""
+
+        // When / Then
+        assertFailsWith<IllegalArgumentException> { Prompt(text) }
     }
 }


### PR DESCRIPTION
Independent cleanup targeting `main`, split out from the in-flight feature work (PR #18) so it can be reviewed and merged on its own.

## What
Removes descriptive, restating, and rationale comments across production sources, keeping the code itself as the source of truth.

Restructures the test suite to a bare Given/When/Then layout: action inputs (including inline literals and constructors) move into `// Given`, the action under test sits under `// When`, and assertions are decoupled under `// Then`. Tests whose entire body is a single inseparable functional call carry no labels, since GWT would mark no real phase (e.g. WebTestClient endpoint tests, context-runner default-bean checks).

## Scope
44 files that exist on `main`. The same cleanup for the local-LLM / image-generation files travels with PR #18, since those files do not exist on `main` yet.

## Heads-up for PR #18
Because this lands the cleaned versions of shared files on `main`, PR #18 will need a rebase and will hit conflicts on those shared files (it still carries the commented versions). Resolving in favour of the cleaned versions is the intended outcome.

## Verification
`./gradlew build` green on this branch: compilation, full test suite, ktlint/Spotless, and jacoco reports. No production logic changed; test names, assertions, and expected values are unchanged, and no tests were added or removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved test structure and readability across multiple test suites with clearer assertion formatting.
  * Restructured internal code organization for better maintainability.

* **Chores**
  * Removed internal documentation and explanatory comments from codebase.
  * Cleaned up unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->