### PR TITLE
test: domain-language test fixtures via java-test-fixtures

### DIFF
--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
         exclude("org.mockito", "mockito-core")
     }
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(testFixtures(project(":beat-the-machine-domain")))
 }
 
 tasks.bootJar {

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -1,25 +1,24 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import com.yonatankarp.beatthemachine.openapi.v1.models.ChallengeStatus
 import com.yonatankarp.beatthemachine.openapi.v1.models.Difficulty
 import com.yonatankarp.beatthemachine.openapi.v1.models.MaskedToken
 import com.yonatankarp.beatthemachine.openapi.v1.models.PictureStatus
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.easyChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import org.junit.jupiter.api.Test
 import java.net.URI
 import kotlin.test.assertEquals
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty as DomainDifficulty
 
 class ChallengeApiMapperTest {
-    private fun challenge() = Challenge.start(Prompt("hello world"), Lives(6))
-
     @Test
     fun `maps a pending picture`() {
         // Given
-        val subject = challenge()
+        val subject = mediumChallenge()
 
         // When
         val response = subject.toApiResponse()
@@ -32,7 +31,7 @@ class ChallengeApiMapperTest {
     @Test
     fun `maps a ready picture with its url`() {
         // Given
-        val subject = challenge().withPicture(Picture.Ready("http://img/1.png"))
+        val subject = mediumChallenge().withPicture(readyPicture("http://img/1.png"))
 
         // When
         val response = subject.toApiResponse()
@@ -45,7 +44,7 @@ class ChallengeApiMapperTest {
     @Test
     fun `maps a failed picture`() {
         // Given
-        val subject = challenge().withPicture(Picture.Failed)
+        val subject = mediumChallenge().withPicture(failedPicture())
 
         // When
         val response = subject.toApiResponse()
@@ -58,7 +57,7 @@ class ChallengeApiMapperTest {
     @Test
     fun `degrades a ready picture with a malformed url to FAILED`() {
         // Given
-        val subject = challenge().withPicture(Picture.Ready("http:// bad url with spaces"))
+        val subject = mediumChallenge().withPicture(readyPicture("http:// bad url with spaces"))
 
         // When
         val response = subject.toApiResponse()
@@ -71,7 +70,7 @@ class ChallengeApiMapperTest {
     @Test
     fun `hides every word while the challenge is in progress`() {
         // Given
-        val subject = challenge()
+        val subject = mediumChallenge()
 
         // When
         val response = subject.toApiResponse()
@@ -84,7 +83,7 @@ class ChallengeApiMapperTest {
     @Test
     fun `reveals the whole prompt once the challenge is lost`() {
         // Given
-        val subject = challenge().forfeit()
+        val subject = lostChallenge()
 
         // When
         val response = subject.toApiResponse()
@@ -97,8 +96,8 @@ class ChallengeApiMapperTest {
     @Test
     fun `maps livesRemaining and the difficulty-derived maxLives`() {
         // Given
-        val mediumChallenge = challenge()
-        val easyChallenge = Challenge.start(Prompt("hello world"), Lives(8), difficulty = DomainDifficulty.EASY)
+        val mediumChallenge = mediumChallenge()
+        val easyChallenge = easyChallenge()
 
         // When
         val medium = mediumChallenge.toApiResponse()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -4,6 +4,7 @@ import com.yonatankarp.beatthemachine.openapi.v1.models.ChallengeStatus
 import com.yonatankarp.beatthemachine.openapi.v1.models.Difficulty
 import com.yonatankarp.beatthemachine.openapi.v1.models.MaskedToken
 import com.yonatankarp.beatthemachine.openapi.v1.models.PictureStatus
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.beatenChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.easyChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
@@ -91,6 +92,19 @@ class ChallengeApiMapperTest {
         // Then
         assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
         assertEquals("LOST", response.status.value)
+    }
+
+    @Test
+    fun `reveals the whole prompt once the challenge is beaten`() {
+        // Given
+        val subject = beatenChallenge()
+
+        // When
+        val response = subject.toApiResponse()
+
+        // Then
+        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
+        assertEquals("BEATEN", response.status.value)
     }
 
     @Test

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -3,7 +3,7 @@ package com.yonatankarp.beatthemachine.input.web
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ class ForfeitChallengeControllerTest(
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/forfeit")
+            .uri("/api/challenges/${aChallengeId().value}/forfeit")
             .exchange()
             .expectStatus()
             .isOk
@@ -37,11 +37,11 @@ class ForfeitChallengeControllerTest(
 
     @Test
     fun `forfeit with concurrent modification returns 409`() {
-        coEvery { forfeitChallenge(any()) } throws OptimisticLockConflict(ChallengeId.new())
+        coEvery { forfeitChallenge(any()) } throws OptimisticLockConflict(aChallengeId())
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/forfeit")
+            .uri("/api/challenges/${aChallengeId().value}/forfeit")
             .exchange()
             .expectStatus()
             .isEqualTo(409)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -3,10 +3,8 @@ package com.yonatankarp.beatthemachine.input.web
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +20,7 @@ class ForfeitChallengeControllerTest(
 
     @Test
     fun `forfeit reveals the prompt and reports LOST`() {
-        coEvery { forfeitChallenge(any()) } returns Challenge.start(Prompt("hello world"), Lives(6)).forfeit()
+        coEvery { forfeitChallenge(any()) } returns lostChallenge()
 
         client
             .post()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -3,10 +3,8 @@ package com.yonatankarp.beatthemachine.input.web
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +20,7 @@ class GetChallengeControllerTest(
 
     @Test
     fun `GET returns the challenge state`() {
-        val challenge = Challenge.start(Prompt("hello world"), Lives(6))
+        val challenge = mediumChallenge()
         coEvery { getChallenge(any()) } returns challenge
 
         client

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -3,7 +3,7 @@ package com.yonatankarp.beatthemachine.input.web
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
@@ -38,11 +38,11 @@ class GetChallengeControllerTest(
 
     @Test
     fun `GET an unknown challenge returns 404`() {
-        coEvery { getChallenge(any()) } throws ChallengeNotFound(ChallengeId.new())
+        coEvery { getChallenge(any()) } throws ChallengeNotFound(aChallengeId())
 
         client
             .get()
-            .uri("/api/challenges/${ChallengeId.new().value}")
+            .uri("/api/challenges/${aChallengeId().value}")
             .exchange()
             .expectStatus()
             .isNotFound

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -5,8 +5,8 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.MakeGuess
 import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
 import com.yonatankarp.beatthemachine.domain.exception.InvalidGuess
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
@@ -30,7 +30,7 @@ class MakeGuessControllerTest(
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/guesses")
+            .uri("/api/challenges/${aChallengeId().value}/guesses")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue("""{"word":"hello"}""")
             .exchange()
@@ -45,11 +45,11 @@ class MakeGuessControllerTest(
 
     @Test
     fun `guessing an unknown challenge returns 404`() {
-        coEvery { makeGuess(any(), any()) } throws ChallengeNotFound(ChallengeId.new())
+        coEvery { makeGuess(any(), any()) } throws ChallengeNotFound(aChallengeId())
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/guesses")
+            .uri("/api/challenges/${aChallengeId().value}/guesses")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue("""{"word":"hello"}""")
             .exchange()
@@ -59,11 +59,11 @@ class MakeGuessControllerTest(
 
     @Test
     fun `guessing on an already-over challenge returns 409`() {
-        coEvery { makeGuess(any(), any()) } throws ChallengeAlreadyOver(ChallengeId.new())
+        coEvery { makeGuess(any(), any()) } throws ChallengeAlreadyOver(aChallengeId())
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/guesses")
+            .uri("/api/challenges/${aChallengeId().value}/guesses")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue("""{"word":"hello"}""")
             .exchange()
@@ -77,7 +77,7 @@ class MakeGuessControllerTest(
 
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/guesses")
+            .uri("/api/challenges/${aChallengeId().value}/guesses")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue("""{"word":"two words"}""")
             .exchange()
@@ -89,7 +89,7 @@ class MakeGuessControllerTest(
     fun `guessing with a blank word returns 422`() {
         client
             .post()
-            .uri("/api/challenges/${ChallengeId.new().value}/guesses")
+            .uri("/api/challenges/${aChallengeId().value}/guesses")
             .contentType(MediaType.APPLICATION_JSON)
             .bodyValue("""{"word":"   "}""")
             .exchange()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -3,14 +3,12 @@ package com.yonatankarp.beatthemachine.input.web
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.MakeGuess
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
 import com.yonatankarp.beatthemachine.domain.exception.InvalidGuess
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asGuess
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,7 +25,7 @@ class MakeGuessControllerTest(
 
     @Test
     fun `a successful guess returns the updated masked prompt`() {
-        val (afterHit, _) = Challenge.start(Prompt("hello world"), Lives(6)).makeGuess(Guess("hello"))
+        val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
         coEvery { makeGuess(any(), any()) } returns (afterHit to GuessOutcome.HIT)
 
         client

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -2,9 +2,7 @@ package com.yonatankarp.beatthemachine.input.web
 
 import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import io.mockk.coEvery
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,7 +18,7 @@ class StartChallengeControllerTest(
 
     @Test
     fun `POST creates a challenge and never leaks the prompt`() {
-        coEvery { startChallenge(any()) } returns Challenge.start(Prompt("hello world"), Lives(6))
+        coEvery { startChallenge(any()) } returns mediumChallenge()
 
         client
             .post()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -3,15 +3,15 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeStore
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPendingChallenges
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryStoreChallenge
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -31,7 +31,7 @@ class PicturePregenerationTest {
         runTest {
             // Given
             val machine = Machine { Picture.Ready("http://img/1.png") }
-            val c = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
+            val c = storeChallenge(mediumChallenge())
 
             // When
             pregeneration(machine, this).enqueue(c.id)
@@ -46,7 +46,7 @@ class PicturePregenerationTest {
         runTest {
             // Given
             val machine = Machine { error("boom") }
-            val c = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
+            val c = storeChallenge(mediumChallenge())
 
             // When
             pregeneration(machine, this).enqueue(c.id)
@@ -72,8 +72,8 @@ class PicturePregenerationTest {
         runTest {
             // Given
             val machine = Machine { Picture.Ready("http://img/retry.png") }
-            val pending = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
-            val done = storeChallenge(Challenge.start(Prompt("foo bar"), Lives(6)).withPicture(Picture.Ready("http://img/done.png")))
+            val pending = storeChallenge(mediumChallenge())
+            val done = storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/done.png")))
 
             // When
             pregeneration(machine, this).retryPending()
@@ -88,7 +88,7 @@ class PicturePregenerationTest {
     fun `a concurrent version bump is retried so the picture still persists`() =
         runTest {
             // Given
-            val seeded = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
+            val seeded = storeChallenge(mediumChallenge())
 
             var firstStore = true
             val racingStore =
@@ -115,8 +115,8 @@ class PicturePregenerationTest {
         runTest {
             // Given
             val machine = Machine { Picture.Ready("http://img/admitted.png") }
-            val admitted = storeChallenge(Challenge.start(Prompt("hello world"), Lives(6)))
-            val shed = storeChallenge(Challenge.start(Prompt("foo bar"), Lives(6)))
+            val admitted = storeChallenge(mediumChallenge())
+            val shed = storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()))
             val pregeneration = pregeneration(machine, this, maxQueued = 1)
 
             // When

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -3,12 +3,12 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryChallengeStore
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindChallengeById
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPendingChallenges
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryStoreChallenge
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
@@ -63,7 +63,7 @@ class PicturePregenerationTest {
             val machine = Machine { Picture.Ready("http://img/1.png") }
 
             // When
-            pregeneration(machine, this).enqueue(ChallengeId.new())
+            pregeneration(machine, this).enqueue(aChallengeId())
             advanceUntilIdle()
         }
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.beatthemachine.output.ai
 
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -26,7 +26,7 @@ class SeedMachineTest {
     fun `returns Failed for an unknown prompt`() =
         runTest {
             // Given
-            val prompt = Prompt("a prompt that is not seeded")
+            val prompt = "a prompt that is not seeded".asPrompt()
 
             // When
             val result = machine.generate(prompt)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class InMemoryFindChallengeByIdTest {
             // Given
             val store = InMemoryChallengeStore()
             val findChallengeById = InMemoryFindChallengeById(store)
-            val unknownId = ChallengeId.new()
+            val unknownId = aChallengeId()
 
             // When
             val found = findChallengeById(unknownId)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -1,9 +1,8 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -17,7 +16,7 @@ class InMemoryFindChallengeByIdTest {
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
             val findChallengeById = InMemoryFindChallengeById(store)
-            val saved = storeChallenge(Challenge.start(Prompt("hello world"), Lives(3)))
+            val saved = storeChallenge(mediumChallenge(lives = 3.lives()))
 
             // When
             val found = findChallengeById(saved.id)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -16,7 +15,7 @@ class InMemoryFindChallengeByIdTest {
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
             val findChallengeById = InMemoryFindChallengeById(store)
-            val saved = storeChallenge(mediumChallenge(lives = 3.lives()))
+            val saved = storeChallenge(mediumChallenge())
 
             // When
             val found = findChallengeById(saved.id)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -1,9 +1,9 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -16,9 +16,9 @@ class InMemoryFindPendingChallengesTest {
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
             val findPendingChallenges = InMemoryFindPendingChallenges(store)
-            val pendingA = storeChallenge(Challenge.start(Prompt("hello world"), Lives(3)))
-            val pendingB = storeChallenge(Challenge.start(Prompt("red fox"), Lives(3)))
-            storeChallenge(Challenge.start(Prompt("foo bar"), Lives(3)).withPicture(Picture.Ready("http://img/1.png")))
+            val pendingA = storeChallenge(mediumChallenge(lives = 3.lives()))
+            val pendingB = storeChallenge(mediumChallenge(lives = 3.lives(), prompt = "red fox".asPrompt()))
+            storeChallenge(mediumChallenge(lives = 3.lives(), prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
 
             // When
             val ids = findPendingChallenges().map { it.id }.toSet()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import kotlinx.coroutines.test.runTest
@@ -16,9 +15,9 @@ class InMemoryFindPendingChallengesTest {
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
             val findPendingChallenges = InMemoryFindPendingChallenges(store)
-            val pendingA = storeChallenge(mediumChallenge(lives = 3.lives()))
-            val pendingB = storeChallenge(mediumChallenge(lives = 3.lives(), prompt = "red fox".asPrompt()))
-            storeChallenge(mediumChallenge(lives = 3.lives(), prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
+            val pendingA = storeChallenge(mediumChallenge())
+            val pendingB = storeChallenge(mediumChallenge(prompt = "red fox".asPrompt()))
+            storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
 
             // When
             val ids = findPendingChallenges().map { it.id }.toSet()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -15,7 +14,7 @@ class InMemoryStoreChallengeTest {
             // Given
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
-            val challenge = mediumChallenge(lives = 3.lives())
+            val challenge = mediumChallenge()
 
             // When
             val saved = storeChallenge(challenge)
@@ -30,7 +29,7 @@ class InMemoryStoreChallengeTest {
             // Given
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
-            val c = mediumChallenge(lives = 3.lives())
+            val c = mediumChallenge()
             storeChallenge(c)
 
             // When / Then

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -1,9 +1,8 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -16,7 +15,7 @@ class InMemoryStoreChallengeTest {
             // Given
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
-            val challenge = Challenge.start(Prompt("hello world"), Lives(3))
+            val challenge = mediumChallenge(lives = 3.lives())
 
             // When
             val saved = storeChallenge(challenge)
@@ -31,7 +30,7 @@ class InMemoryStoreChallengeTest {
             // Given
             val store = InMemoryChallengeStore()
             val storeChallenge = InMemoryStoreChallenge(store)
-            val c = Challenge.start(Prompt("hello world"), Lives(3))
+            val c = mediumChallenge(lives = 3.lives())
             storeChallenge(c)
 
             // When / Then

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
@@ -44,7 +44,7 @@ class SqliteFindChallengeByIdIT {
     fun `returns null for an unknown id`() =
         runTest {
             // Given
-            val unknownId = ChallengeId.new()
+            val unknownId = aChallengeId()
 
             // When
             val found = findChallengeById(unknownId)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
@@ -1,9 +1,9 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class SqliteFindChallengeByIdIT {
     fun `finds a stored challenge with its fields intact`() =
         runTest {
             // Given
-            val c = Challenge.start(Prompt("pixel art cat"), Lives(5))
+            val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
             storeChallenge(c)
 
             // When

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
@@ -1,9 +1,10 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -25,10 +26,10 @@ class SqliteFindPendingChallengesIT {
     fun `returns only challenges whose picture is pending`() =
         runTest {
             // Given
-            val pendingA = storeChallenge(Challenge.start(Prompt("pending one"), Lives(2), picture = Picture.Pending))
-            val pendingB = storeChallenge(Challenge.start(Prompt("pending two"), Lives(2), picture = Picture.Pending))
-            storeChallenge(Challenge.start(Prompt("ready pic"), Lives(2), picture = Picture.Ready("https://example.com/img.png")))
-            storeChallenge(Challenge.start(Prompt("failed pic"), Lives(2), picture = Picture.Failed))
+            val pendingA = storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "pending one".asPrompt()))
+            val pendingB = storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "pending two".asPrompt()))
+            storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "ready pic".asPrompt(), picture = readyPicture()))
+            storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "failed pic".asPrompt(), picture = failedPicture()))
 
             // When
             val ids = findPendingChallenges().map { it.id }.toSet()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
@@ -1,7 +1,6 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
@@ -26,10 +25,10 @@ class SqliteFindPendingChallengesIT {
     fun `returns only challenges whose picture is pending`() =
         runTest {
             // Given
-            val pendingA = storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "pending one".asPrompt()))
-            val pendingB = storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "pending two".asPrompt()))
-            storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "ready pic".asPrompt(), picture = readyPicture()))
-            storeChallenge(mediumChallenge(lives = 2.lives(), prompt = "failed pic".asPrompt(), picture = failedPicture()))
+            val pendingA = storeChallenge(mediumChallenge(prompt = "pending one".asPrompt()))
+            val pendingB = storeChallenge(mediumChallenge(prompt = "pending two".asPrompt()))
+            storeChallenge(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
+            storeChallenge(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
 
             // When
             val ids = findPendingChallenges().map { it.id }.toSet()

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
@@ -32,7 +32,7 @@ class SqliteStoreChallengeIT {
     fun `stores a fresh challenge and bumps the version`() =
         runTest {
             // Given
-            val challenge = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
+            val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
 
             // When
             val saved = storeChallenge(challenge)
@@ -45,7 +45,7 @@ class SqliteStoreChallengeIT {
     fun `allows sequential stores with updated versions`() =
         runTest {
             // Given
-            val challenge = mediumChallenge(lives = 3.lives(), prompt = "sequential".asPrompt())
+            val challenge = mediumChallenge(prompt = "sequential".asPrompt())
 
             // When
             val v1 = storeChallenge(challenge)
@@ -60,7 +60,7 @@ class SqliteStoreChallengeIT {
     fun `rejects a stale version on second store`() =
         runTest {
             // Given
-            val c = mediumChallenge(lives = 3.lives())
+            val c = mediumChallenge()
             storeChallenge(c)
 
             // When / Then
@@ -87,9 +87,9 @@ class SqliteStoreChallengeIT {
     fun `persists picture states correctly`() =
         runTest {
             // Given
-            val pending = mediumChallenge(lives = 2.lives(), prompt = "pending pic".asPrompt())
-            val ready = mediumChallenge(lives = 2.lives(), prompt = "ready pic".asPrompt(), picture = readyPicture())
-            val failed = mediumChallenge(lives = 2.lives(), prompt = "failed pic".asPrompt(), picture = failedPicture())
+            val pending = mediumChallenge(prompt = "pending pic".asPrompt())
+            val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
+            val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
 
             // When
             storeChallenge(pending)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
@@ -3,9 +3,12 @@ package com.yonatankarp.beatthemachine.output.persistence.sqlite
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,7 +32,7 @@ class SqliteStoreChallengeIT {
     fun `stores a fresh challenge and bumps the version`() =
         runTest {
             // Given
-            val challenge = Challenge.start(Prompt("pixel art cat"), Lives(5))
+            val challenge = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
 
             // When
             val saved = storeChallenge(challenge)
@@ -42,7 +45,7 @@ class SqliteStoreChallengeIT {
     fun `allows sequential stores with updated versions`() =
         runTest {
             // Given
-            val challenge = Challenge.start(Prompt("sequential"), Lives(3))
+            val challenge = mediumChallenge(lives = 3.lives(), prompt = "sequential".asPrompt())
 
             // When
             val v1 = storeChallenge(challenge)
@@ -57,7 +60,7 @@ class SqliteStoreChallengeIT {
     fun `rejects a stale version on second store`() =
         runTest {
             // Given
-            val c = Challenge.start(Prompt("hello world"), Lives(3))
+            val c = mediumChallenge(lives = 3.lives())
             storeChallenge(c)
 
             // When / Then
@@ -72,7 +75,7 @@ class SqliteStoreChallengeIT {
 
             // When / Then
             difficulties.forEach { diff ->
-                val c = Challenge.start(Prompt("test prompt"), Lives(2), difficulty = diff)
+                val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
                 storeChallenge(c)
                 val found = findChallengeById(c.id)
                 assertNotNull(found)
@@ -84,9 +87,9 @@ class SqliteStoreChallengeIT {
     fun `persists picture states correctly`() =
         runTest {
             // Given
-            val pending = Challenge.start(Prompt("pending pic"), Lives(2), picture = Picture.Pending)
-            val ready = Challenge.start(Prompt("ready pic"), Lives(2), picture = Picture.Ready("https://example.com/img.png"))
-            val failed = Challenge.start(Prompt("failed pic"), Lives(2), picture = Picture.Failed)
+            val pending = mediumChallenge(lives = 2.lives(), prompt = "pending pic".asPrompt())
+            val ready = mediumChallenge(lives = 2.lives(), prompt = "ready pic".asPrompt(), picture = readyPicture())
+            val failed = mediumChallenge(lives = 2.lives(), prompt = "failed pic".asPrompt(), picture = failedPicture())
 
             // When
             storeChallenge(pending)

--- a/beat-the-machine-application/build.gradle.kts
+++ b/beat-the-machine-application/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(testFixtures(project(":beat-the-machine-domain")))
 }
 
 tasks.withType<Test> {

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -2,8 +2,8 @@ package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ class ForfeitChallengeUseCaseTest {
         runTest {
             // Given
             val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-            val unknownId = ChallengeId.new()
+            val unknownId = aChallengeId()
 
             // When / Then
             assertFailsWith<ChallengeNotFound> {

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -4,8 +4,8 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -14,7 +14,7 @@ import kotlin.test.assertFailsWith
 class ForfeitChallengeUseCaseTest {
     private val store = FakeChallengeStore()
 
-    private suspend fun seed(): Challenge = store(Challenge.start(Prompt("hello world"), Lives(3)))
+    private suspend fun seed(): Challenge = store(mediumChallenge(lives = 3.lives()))
 
     @Test
     fun `forfeit loads the challenge, sets LOST, and persists it`() =

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -4,7 +4,6 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -14,7 +13,7 @@ import kotlin.test.assertFailsWith
 class ForfeitChallengeUseCaseTest {
     private val store = FakeChallengeStore()
 
-    private suspend fun seed(): Challenge = store(mediumChallenge(lives = 3.lives()))
+    private suspend fun seed(): Challenge = store(mediumChallenge())
 
     @Test
     fun `forfeit loads the challenge, sets LOST, and persists it`() =

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
@@ -30,7 +30,7 @@ class GetChallengeUseCaseTest {
     fun `throws ChallengeNotFound for an unknown id`() =
         runTest {
             // Given
-            val unknownId = ChallengeId.new()
+            val unknownId = aChallengeId()
 
             // When / Then
             assertFailsWith<ChallengeNotFound> { getChallenge(unknownId) }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -1,10 +1,9 @@
 package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -18,7 +17,7 @@ class GetChallengeUseCaseTest {
     fun `returns a challenge that exists`() =
         runTest {
             // Given
-            val challenge = store(Challenge.start(Prompt("red fox"), Lives(6)))
+            val challenge = store(mediumChallenge(prompt = "red fox".asPrompt()))
 
             // When
             val result = getChallenge(challenge.id)

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -4,9 +4,9 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
-import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
+import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
@@ -41,7 +41,7 @@ class MakeGuessUseCaseTest {
         runTest {
             // Given
             val makeGuess = MakeGuessUseCase(store, store)
-            val unknownId = ChallengeId.new()
+            val unknownId = aChallengeId()
             val guess = "hello".asGuess()
 
             // When / Then

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -8,7 +8,6 @@ import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
-import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -18,7 +17,7 @@ import kotlin.test.assertFailsWith
 class MakeGuessUseCaseTest {
     private val store = FakeChallengeStore()
 
-    private suspend fun seed(): Challenge = store(mediumChallenge(lives = 3.lives()))
+    private suspend fun seed(): Challenge = store(mediumChallenge())
 
     @Test
     fun `a hit is persisted`() =

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -5,11 +5,11 @@ import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConfli
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
-import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asGuess
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -18,7 +18,7 @@ import kotlin.test.assertFailsWith
 class MakeGuessUseCaseTest {
     private val store = FakeChallengeStore()
 
-    private suspend fun seed(): Challenge = store(Challenge.start(Prompt("hello world"), Lives(3)))
+    private suspend fun seed(): Challenge = store(mediumChallenge(lives = 3.lives()))
 
     @Test
     fun `a hit is persisted`() =
@@ -26,7 +26,7 @@ class MakeGuessUseCaseTest {
             // Given
             val c = seed()
             val makeGuess = MakeGuessUseCase(store, store)
-            val guess = Guess("hello")
+            val guess = "hello".asGuess()
 
             // When
             val (updated, outcome) = makeGuess(c.id, guess)
@@ -43,7 +43,7 @@ class MakeGuessUseCaseTest {
             // Given
             val makeGuess = MakeGuessUseCase(store, store)
             val unknownId = ChallengeId.new()
-            val guess = Guess("hello")
+            val guess = "hello".asGuess()
 
             // When / Then
             assertFailsWith<ChallengeNotFound> {
@@ -58,7 +58,7 @@ class MakeGuessUseCaseTest {
             val c = seed()
             val conflicting = StoreChallenge { throw OptimisticLockConflict(it.id) }
             val makeGuess = MakeGuessUseCase(store, conflicting)
-            val guess = Guess("hello")
+            val guess = "hello".asGuess()
 
             // When / Then
             assertFailsWith<OptimisticLockConflict> {

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -5,14 +5,14 @@ import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class StartChallengeUseCaseTest {
-    private val prompts = PromptSource { Prompt("hello world") }
+    private val prompts = PromptSource { "hello world".asPrompt() }
     private val store = FakeChallengeStore()
 
     @Test

--- a/beat-the-machine-domain/build.gradle.kts
+++ b/beat-the-machine-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jacoco
     alias(libs.plugins.kotlin.jvm)
+    `java-test-fixtures`
 }
 
 kotlin {

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -2,12 +2,13 @@ package com.yonatankarp.beatthemachine.domain.entity
 
 import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
-import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
-import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
-import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asGuess
+import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -15,16 +16,11 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
 class ChallengeTest {
-    private fun newChallenge(
-        prompt: String = "hello world",
-        lives: Int = 3,
-    ) = Challenge.start(Prompt(prompt), Lives(lives))
-
     @Test
     fun `a correct guess reveals the word and stays in progress`() {
         // Given
-        val challenge = newChallenge()
-        val guess = Guess("hello")
+        val challenge = mediumChallenge(lives = 3.lives())
+        val guess = "hello".asGuess()
 
         // When
         val (updated, outcome) = challenge.makeGuess(guess)
@@ -38,8 +34,8 @@ class ChallengeTest {
     @Test
     fun `a wrong guess costs a life`() {
         // Given
-        val challenge = newChallenge()
-        val guess = Guess("nope")
+        val challenge = mediumChallenge(lives = 3.lives())
+        val guess = "nope".asGuess()
 
         // When
         val (updated, outcome) = challenge.makeGuess(guess)
@@ -52,11 +48,11 @@ class ChallengeTest {
     @Test
     fun `guessing every word beats the machine`() {
         // Given
-        val challenge = newChallenge()
-        val (afterFirst, _) = challenge.makeGuess(Guess("hello"))
+        val challenge = mediumChallenge(lives = 3.lives())
+        val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
 
         // When
-        val (afterSecond, outcome) = afterFirst.makeGuess(Guess("world"))
+        val (afterSecond, outcome) = afterFirst.makeGuess("world".asGuess())
 
         // Then
         assertEquals(GuessOutcome.HIT, outcome)
@@ -66,8 +62,8 @@ class ChallengeTest {
     @Test
     fun `running out of lives loses the challenge`() {
         // Given
-        val challenge = newChallenge(lives = 1)
-        val guess = Guess("nope")
+        val challenge = mediumChallenge(lives = 1.lives())
+        val guess = "nope".asGuess()
 
         // When
         val (updated, _) = challenge.makeGuess(guess)
@@ -79,11 +75,11 @@ class ChallengeTest {
     @Test
     fun `a duplicate guess is a no-op and costs no life`() {
         // Given
-        val challenge = newChallenge()
-        val (afterFirst, _) = challenge.makeGuess(Guess("nope"))
+        val challenge = mediumChallenge(lives = 3.lives())
+        val (afterFirst, _) = challenge.makeGuess("nope".asGuess())
 
         // When
-        val (afterSecond, outcome) = afterFirst.makeGuess(Guess("Nope"))
+        val (afterSecond, outcome) = afterFirst.makeGuess("Nope".asGuess())
 
         // Then
         assertEquals(GuessOutcome.DUPLICATE, outcome)
@@ -93,8 +89,8 @@ class ChallengeTest {
     @Test
     fun `makeGuess does not mutate the receiver`() {
         // Given
-        val challenge = newChallenge()
-        val guess = Guess("nope")
+        val challenge = mediumChallenge(lives = 3.lives())
+        val guess = "nope".asGuess()
 
         // When
         challenge.makeGuess(guess)
@@ -107,16 +103,16 @@ class ChallengeTest {
     @Test
     fun `guessing after the challenge is over is rejected`() {
         // Given
-        val (lost, _) = newChallenge(lives = 1).makeGuess(Guess("nope"))
+        val (lost, _) = mediumChallenge(lives = 1.lives()).makeGuess("nope".asGuess())
 
         // When / Then
-        assertFailsWith<ChallengeAlreadyOver> { lost.makeGuess(Guess("hello")) }
+        assertFailsWith<ChallengeAlreadyOver> { lost.makeGuess("hello".asGuess()) }
     }
 
     @Test
     fun `forfeit reveals the prompt and loses`() {
         // Given
-        val challenge = newChallenge()
+        val challenge = mediumChallenge(lives = 3.lives())
 
         // When
         val forfeited = challenge.forfeit()
@@ -129,7 +125,7 @@ class ChallengeTest {
     @Test
     fun `forfeit after the challenge is over is rejected`() {
         // Given
-        val forfeited = newChallenge().forfeit()
+        val forfeited = mediumChallenge(lives = 3.lives()).forfeit()
 
         // When / Then
         assertFailsWith<ChallengeAlreadyOver> { forfeited.forfeit() }
@@ -138,8 +134,8 @@ class ChallengeTest {
     @Test
     fun `withPicture returns an independent copy at the same version`() {
         // Given
-        val challenge = newChallenge()
-        val newPicture = Picture.Ready("https://example.com/img.png")
+        val challenge = mediumChallenge(lives = 3.lives())
+        val newPicture = readyPicture("https://example.com/img.png")
 
         // When
         val updated = challenge.withPicture(newPicture)

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -48,7 +48,7 @@ class ChallengeTest {
     @Test
     fun `guessing every word beats the machine`() {
         // Given
-        val challenge = mediumChallenge(lives = 3.lives())
+        val challenge = mediumChallenge()
         val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
 
         // When
@@ -112,7 +112,7 @@ class ChallengeTest {
     @Test
     fun `forfeit reveals the prompt and loses`() {
         // Given
-        val challenge = mediumChallenge(lives = 3.lives())
+        val challenge = mediumChallenge()
 
         // When
         val forfeited = challenge.forfeit()
@@ -125,7 +125,7 @@ class ChallengeTest {
     @Test
     fun `forfeit after the challenge is over is rejected`() {
         // Given
-        val forfeited = mediumChallenge(lives = 3.lives()).forfeit()
+        val forfeited = mediumChallenge().forfeit()
 
         // When / Then
         assertFailsWith<ChallengeAlreadyOver> { forfeited.forfeit() }
@@ -134,7 +134,7 @@ class ChallengeTest {
     @Test
     fun `withPicture returns an independent copy at the same version`() {
         // Given
-        val challenge = mediumChallenge(lives = 3.lives())
+        val challenge = mediumChallenge()
         val newPicture = readyPicture("https://example.com/img.png")
 
         // When

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
@@ -1,17 +1,17 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
+import com.yonatankarp.beatthemachine.test.dsl.asGuess
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class MaskedPromptTest {
-    private fun prompt(t: String) = Prompt(t)
-
     @Test
     fun `hides every word when there are no guesses`() {
         // Given
-        val secret = prompt("hello world")
+        val secret = "hello world".asPrompt()
         val guesses = emptySet<Guess>()
 
         // When
@@ -25,8 +25,8 @@ class MaskedPromptTest {
     @Test
     fun `reveals a matching word case-insensitively`() {
         // Given
-        val secret = prompt("Hello World")
-        val guesses = setOf(Guess("hello"))
+        val secret = "Hello World".asPrompt()
+        val guesses = setOf("hello".asGuess())
 
         // When
         val masked = MaskedPrompt.of(secret, guesses)
@@ -39,8 +39,8 @@ class MaskedPromptTest {
     @Test
     fun `reveals every occurrence of a repeated word`() {
         // Given
-        val secret = prompt("na na batman")
-        val guesses = setOf(Guess("na"))
+        val secret = "na na batman".asPrompt()
+        val guesses = setOf("na".asGuess())
 
         // When
         val masked = MaskedPrompt.of(secret, guesses)
@@ -55,8 +55,8 @@ class MaskedPromptTest {
     @Test
     fun `collapses arbitrary whitespace using one rule`() {
         // Given
-        val secret = prompt("hello\t \nworld")
-        val guesses = setOf(Guess("world"))
+        val secret = "hello\t \nworld".asPrompt()
+        val guesses = setOf("world".asGuess())
 
         // When
         val masked = MaskedPrompt.of(secret, guesses)
@@ -69,8 +69,8 @@ class MaskedPromptTest {
     @Test
     fun `is fully revealed when all words are guessed`() {
         // Given
-        val secret = prompt("hello world")
-        val guesses = setOf(Guess("hello"), Guess("world"))
+        val secret = "hello world".asPrompt()
+        val guesses = setOf("hello".asGuess(), "world".asGuess())
 
         // When
         val masked = MaskedPrompt.of(secret, guesses)

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/dsl/TestDsl.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/dsl/TestDsl.kt
@@ -1,0 +1,14 @@
+package com.yonatankarp.beatthemachine.test.dsl
+
+import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
+import com.yonatankarp.beatthemachine.domain.valueobject.Guess
+import com.yonatankarp.beatthemachine.domain.valueobject.Lives
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+
+fun String.asPrompt(): Prompt = Prompt(this)
+
+fun String.asGuess(): Guess = Guess(this)
+
+fun Int.lives(): Lives = Lives(this)
+
+fun aChallengeId(): ChallengeId = ChallengeId.new()

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
@@ -1,0 +1,36 @@
+package com.yonatankarp.beatthemachine.test.fixtures
+
+import com.yonatankarp.beatthemachine.domain.entity.Challenge
+import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Guess
+import com.yonatankarp.beatthemachine.domain.valueobject.Lives
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+
+object Challenges {
+    fun easyChallenge(
+        lives: Lives = Lives.initialFor(Difficulty.EASY),
+        prompt: Prompt = "hello world".asPrompt(),
+        picture: Picture = Picture.Pending,
+    ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.EASY)
+
+    fun mediumChallenge(
+        lives: Lives = Lives.initialFor(Difficulty.MEDIUM),
+        prompt: Prompt = "hello world".asPrompt(),
+        picture: Picture = Picture.Pending,
+    ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.MEDIUM)
+
+    fun hardChallenge(
+        lives: Lives = Lives.initialFor(Difficulty.HARD),
+        prompt: Prompt = "hello world".asPrompt(),
+        picture: Picture = Picture.Pending,
+    ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.HARD)
+
+    fun lostChallenge(prompt: Prompt = "hello world".asPrompt()): Challenge = mediumChallenge(prompt = prompt).forfeit()
+
+    fun beatenChallenge(prompt: Prompt = "hello world".asPrompt()): Challenge =
+        prompt.words().fold(mediumChallenge(prompt = prompt)) { challenge, word ->
+            challenge.makeGuess(Guess(word)).first
+        }
+}

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
@@ -2,10 +2,10 @@ package com.yonatankarp.beatthemachine.test.fixtures
 
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
-import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 
 object Challenges {
@@ -31,6 +31,6 @@ object Challenges {
 
     fun beatenChallenge(prompt: Prompt = "hello world".asPrompt()): Challenge =
         prompt.words().fold(mediumChallenge(prompt = prompt)) { challenge, word ->
-            challenge.makeGuess(Guess(word)).first
+            challenge.makeGuess(word.asGuess()).first
         }
 }

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Pictures.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Pictures.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.beatthemachine.test.fixtures
+
+import com.yonatankarp.beatthemachine.domain.valueobject.Picture
+
+object Pictures {
+    fun pendingPicture(): Picture = Picture.Pending
+
+    fun readyPicture(url: String = "https://example.com/img.png"): Picture = Picture.Ready(url)
+
+    fun failedPicture(): Picture = Picture.Failed
+}


### PR DESCRIPTION
Introduces Gradle's `java-test-fixtures` plugin on the domain module and a domain-language fixture surface, then migrates the whole test suite onto it. Style follows the refinancing project: `object` factory functions named in domain language plus a few extension functions for the leaf value objects (no builders, no `@DslMarker`).

## What
- `java-test-fixtures` applied on `beat-the-machine-domain`; application and adapters consume it via `testImplementation(testFixtures(project(":beat-the-machine-domain")))`.
- Fixture surface in `domain/src/testFixtures`:
  - `test/dsl/TestDsl.kt`: `String.asPrompt()`, `String.asGuess()`, `Int.lives()`, `aChallengeId()`.
  - `test/fixtures/Pictures.kt`: `pendingPicture()`, `readyPicture(url)`, `failedPicture()`.
  - `test/fixtures/Challenges.kt`: `easyChallenge`/`mediumChallenge`/`hardChallenge` (lives default to `Lives.initialFor(difficulty)`), `lostChallenge`, `beatenChallenge`.
- Migrated domain, application, and adapter tests to the fixtures, deleting ad-hoc local helpers (`newChallenge`, `challenge()`).
- Redundant arguments dropped so tests rely on factory defaults; `lives = N.lives()` overrides kept only where a test asserts on the life count.
- Closed a coverage gap surfaced by an orphaned fixture: added the missing `BEATEN` challenge mapping test to `ChallengeApiMapperTest` (it previously covered only `IN_PROGRESS` and `LOST`).

## Constraints honored
- Value-object SUT constructions (`Guess`/`Prompt`/`Lives`/`Picture` in their own tests) and OpenAPI `MaskedToken`/`Difficulty.toDomain` left as the real API; only arrange-side constructions migrated.
- No production (`src/main`) changes.

## Verification
`./gradlew build` green: compile, full suite, ktlint/Spotless, jacoco. Test counts: domain 29, application 9, adapters 51 (+1 new BEATEN test). Final whole-branch review (most-capable model) returned READY TO MERGE with no Critical/Important findings.