### PR TITLE
test: migrate the test suite to testBalloon + testballoon-spring + Kotest

### DIFF
--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -4,8 +4,11 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.testballoon)
     alias(libs.plugins.openapi.contracts)
 }
+
+extra["kotlin.version"] = libs.versions.kotlin.get()
 
 kotlin {
     jvmToolchain {
@@ -25,11 +28,21 @@ dependencies {
     implementation(libs.bundles.kotlinx.coroutines)
 
     testImplementation(libs.bundles.unit.test)
-    testImplementation(libs.bundles.spring.boot.test) {
-        exclude("org.mockito", "mockito-core")
-    }
+    testImplementation(libs.bundles.spring.boot.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.bootJar {

--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.bundles.spring.boot.test)
+    testImplementation(libs.springmockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
 
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.bundles.spring.boot.test)
-    testImplementation(libs.springmockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/ApplicationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/ApplicationTest.kt
@@ -1,11 +1,15 @@
 package com.yonatankarp.beatthemachine
 
-import org.junit.jupiter.api.Test
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class ApplicationTest {
-    @Test
-    fun `context loads`() {
+class ApplicationContext : SpringTestConfig()
+
+val ApplicationSuite by testSuite {
+    springTest<ApplicationContext> {
+        test("context loads") {}
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/HealthEndpointTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/HealthEndpointTest.kt
@@ -1,26 +1,28 @@
 package com.yonatankarp.beatthemachine
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class HealthEndpointTest(
-    @Autowired val client: WebTestClient,
-) {
-    @Test
-    fun `health endpoint reports UP`() {
-        client
-            .get()
-            .uri("/health")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("UP")
+class HealthEndpointContext : SpringTestConfig()
+
+val HealthEndpointSuite by testSuite {
+    springTest<HealthEndpointContext> {
+        test("health endpoint reports UP") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/health")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("UP")
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
@@ -1,34 +1,25 @@
 package com.yonatankarp.beatthemachine.config
 
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
-import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
-class PictureScopeTest {
-    @Test
-    fun `is active before shutdown`() {
-        // Given
+val PictureScopeSuite by testSuite {
+    test("is active before shutdown") {
         val scope = PictureScope()
 
-        // When
-        val active = scope.isActive
-
-        // Then
-        assertTrue(active)
+        scope.isActive.shouldBeTrue()
     }
 
-    @Test
-    fun `destroy cancels the scope so no work outlives the application`() {
-        // Given
+    test("destroy cancels the scope so no work outlives the application") {
         val scope = PictureScope()
 
-        // When
         scope.destroy()
 
-        // Then
-        assertFalse(scope.isActive)
-        assertTrue(scope.coroutineContext.job.isCancelled)
+        scope.isActive.shouldBeFalse()
+        scope.coroutineContext.job.isCancelled
+            .shouldBeTrue()
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -10,14 +10,13 @@ import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import org.junit.jupiter.api.Test
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import java.net.URI
-import kotlin.test.assertEquals
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty as DomainDifficulty
 
-class ChallengeApiMapperTest {
-    @Test
-    fun `maps a pending picture`() {
+val ChallengeApiMapperSuite by testSuite {
+    test("maps a pending picture") {
         // Given
         val subject = mediumChallenge()
 
@@ -25,12 +24,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(PictureStatus.PENDING, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.PENDING
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `maps a ready picture with its url`() {
+    test("maps a ready picture with its url") {
         // Given
         val subject = mediumChallenge().withPicture(readyPicture("http://img/1.png"))
 
@@ -38,12 +36,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(PictureStatus.READY, response.picture.status)
-        assertEquals(URI.create("http://img/1.png"), response.picture.url)
+        response.picture.status shouldBe PictureStatus.READY
+        response.picture.url shouldBe URI.create("http://img/1.png")
     }
 
-    @Test
-    fun `maps a failed picture`() {
+    test("maps a failed picture") {
         // Given
         val subject = mediumChallenge().withPicture(failedPicture())
 
@@ -51,12 +48,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(PictureStatus.FAILED, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.FAILED
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `degrades a ready picture with a malformed url to FAILED`() {
+    test("degrades a ready picture with a malformed url to FAILED") {
         // Given
         val subject = mediumChallenge().withPicture(readyPicture("http:// bad url with spaces"))
 
@@ -64,12 +60,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(PictureStatus.FAILED, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.FAILED
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `hides every word while the challenge is in progress`() {
+    test("hides every word while the challenge is in progress") {
         // Given
         val subject = mediumChallenge()
 
@@ -77,12 +72,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5)), response.maskedPrompt)
-        assertEquals(ChallengeStatus.IN_PROGRESS, response.status)
+        response.maskedPrompt shouldBe listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5))
+        response.status shouldBe ChallengeStatus.IN_PROGRESS
     }
 
-    @Test
-    fun `reveals the whole prompt once the challenge is lost`() {
+    test("reveals the whole prompt once the challenge is lost") {
         // Given
         val subject = lostChallenge()
 
@@ -90,12 +84,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
-        assertEquals("LOST", response.status.value)
+        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+        response.status.value shouldBe "LOST"
     }
 
-    @Test
-    fun `reveals the whole prompt once the challenge is beaten`() {
+    test("reveals the whole prompt once the challenge is beaten") {
         // Given
         val subject = beatenChallenge()
 
@@ -103,12 +96,11 @@ class ChallengeApiMapperTest {
         val response = subject.toApiResponse()
 
         // Then
-        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
-        assertEquals("BEATEN", response.status.value)
+        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+        response.status.value shouldBe "BEATEN"
     }
 
-    @Test
-    fun `maps livesRemaining and the difficulty-derived maxLives`() {
+    test("maps livesRemaining and the difficulty-derived maxLives") {
         // Given
         val mediumChallenge = mediumChallenge()
         val easyChallenge = easyChallenge()
@@ -118,21 +110,20 @@ class ChallengeApiMapperTest {
         val easy = easyChallenge.toApiResponse()
 
         // Then
-        assertEquals(6, medium.livesRemaining)
-        assertEquals(6, medium.maxLives)
-        assertEquals(8, easy.maxLives)
+        medium.livesRemaining shouldBe 6
+        medium.maxLives shouldBe 6
+        easy.maxLives shouldBe 8
     }
 
-    @Test
-    fun `Difficulty toDomain maps each value to the same-named domain Difficulty`() {
+    test("Difficulty toDomain maps each value to the same-named domain Difficulty") {
         // When
         val easy = Difficulty.EASY.toDomain()
         val medium = Difficulty.MEDIUM.toDomain()
         val hard = Difficulty.HARD.toDomain()
 
         // Then
-        assertEquals(DomainDifficulty.EASY, easy)
-        assertEquals(DomainDifficulty.MEDIUM, medium)
-        assertEquals(DomainDifficulty.HARD, hard)
+        easy shouldBe DomainDifficulty.EASY
+        medium shouldBe DomainDifficulty.MEDIUM
+        hard shouldBe DomainDifficulty.HARD
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -1,49 +1,48 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(ForfeitChallengeController::class)
-class ForfeitChallengeControllerTest(
-    @Autowired val client: WebTestClient,
-) {
-    @MockkBean
-    lateinit var forfeitChallenge: ForfeitChallenge
+class ForfeitChallengeWebContext : SpringTestConfig()
 
-    @Test
-    fun `forfeit reveals the prompt and reports LOST`() {
-        coEvery { forfeitChallenge(any()) } returns lostChallenge()
+val ForfeitChallengeControllerSuite by testSuite {
+    springTest<ForfeitChallengeWebContext> {
+        val forfeitChallenge = mockBean<ForfeitChallenge>()
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/forfeit")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("LOST")
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(true)
-    }
+        test("forfeit reveals the prompt and reports LOST") {
+            coEvery { forfeitChallenge(any()) } returns lostChallenge()
 
-    @Test
-    fun `forfeit with concurrent modification returns 409`() {
-        coEvery { forfeitChallenge(any()) } throws OptimisticLockConflict(aChallengeId())
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/forfeit")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("LOST")
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(true)
+        }
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/forfeit")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(409)
+        test("forfeit with concurrent modification returns 409") {
+            coEvery { forfeitChallenge(any()) } throws OptimisticLockConflict(aChallengeId())
+
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/forfeit")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(409)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -1,60 +1,58 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(GetChallengeController::class)
-class GetChallengeControllerTest(
-    @Autowired val client: WebTestClient,
-) {
-    @MockkBean
-    lateinit var getChallenge: GetChallenge
+class GetChallengeWebContext : SpringTestConfig()
 
-    @Test
-    fun `GET returns the challenge state`() {
-        val challenge = mediumChallenge()
-        coEvery { getChallenge(any()) } returns challenge
+val GetChallengeControllerSuite by testSuite {
+    springTest<GetChallengeWebContext> {
+        val getChallenge = mockBean<GetChallenge>()
 
-        client
-            .get()
-            .uri("/api/challenges/${challenge.id.value}")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("IN_PROGRESS")
-            .jsonPath("$.livesRemaining")
-            .isEqualTo(6)
-    }
+        test("GET returns the challenge state") {
+            val challenge = mediumChallenge()
+            coEvery { getChallenge(any()) } returns challenge
 
-    @Test
-    fun `GET an unknown challenge returns 404`() {
-        coEvery { getChallenge(any()) } throws ChallengeNotFound(aChallengeId())
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/${challenge.id.value}")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("IN_PROGRESS")
+                .jsonPath("$.livesRemaining")
+                .isEqualTo(6)
+        }
 
-        client
-            .get()
-            .uri("/api/challenges/${aChallengeId().value}")
-            .exchange()
-            .expectStatus()
-            .isNotFound
-    }
+        test("GET an unknown challenge returns 404") {
+            coEvery { getChallenge(any()) } throws ChallengeNotFound(aChallengeId())
 
-    @Test
-    fun `a malformed challenge id returns 422`() {
-        client
-            .get()
-            .uri("/api/challenges/not-a-uuid")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/${aChallengeId().value}")
+                .exchange()
+                .expectStatus()
+                .isNotFound
+        }
+
+        test("a malformed challenge id returns 422") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/not-a-uuid")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -1,6 +1,5 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.MakeGuess
 import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
@@ -9,91 +8,88 @@ import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(MakeGuessController::class)
-class MakeGuessControllerTest(
-    @Autowired val client: WebTestClient,
-) {
-    @MockkBean
-    lateinit var makeGuess: MakeGuess
+class MakeGuessWebContext : SpringTestConfig()
 
-    @Test
-    fun `a successful guess returns the updated masked prompt`() {
-        val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
-        coEvery { makeGuess(any(), any()) } returns (afterHit to GuessOutcome.HIT)
+val MakeGuessControllerSuite by testSuite {
+    springTest<MakeGuessWebContext> {
+        val makeGuess = mockBean<MakeGuess>()
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(true)
-            .jsonPath("$.maskedPrompt[0].word")
-            .isEqualTo("hello")
-    }
+        test("a successful guess returns the updated masked prompt") {
+            val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
+            coEvery { makeGuess(any(), any()) } returns (afterHit to GuessOutcome.HIT)
 
-    @Test
-    fun `guessing an unknown challenge returns 404`() {
-        coEvery { makeGuess(any(), any()) } throws ChallengeNotFound(aChallengeId())
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(true)
+                .jsonPath("$.maskedPrompt[0].word")
+                .isEqualTo("hello")
+        }
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isNotFound
-    }
+        test("guessing an unknown challenge returns 404") {
+            coEvery { makeGuess(any(), any()) } throws ChallengeNotFound(aChallengeId())
 
-    @Test
-    fun `guessing on an already-over challenge returns 409`() {
-        coEvery { makeGuess(any(), any()) } throws ChallengeAlreadyOver(aChallengeId())
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isNotFound
+        }
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(409)
-    }
+        test("guessing on an already-over challenge returns 409") {
+            coEvery { makeGuess(any(), any()) } throws ChallengeAlreadyOver(aChallengeId())
 
-    @Test
-    fun `a domain-rejected guess returns 422`() {
-        coEvery { makeGuess(any(), any()) } throws InvalidGuess("not a single word")
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(409)
+        }
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"two words"}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
-    }
+        test("a domain-rejected guess returns 422") {
+            coEvery { makeGuess(any(), any()) } throws InvalidGuess("not a single word")
 
-    @Test
-    fun `guessing with a blank word returns 422`() {
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"   "}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"two words"}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
+
+        test("guessing with a blank word returns 422") {
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"   "}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
@@ -1,33 +1,35 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class SecurityHeadersFilterTest(
-    @Autowired private val client: WebTestClient,
-) {
-    @Test
-    fun `every response carries the security headers`() {
-        client
-            .get()
-            .uri("/")
-            .exchange()
-            .expectHeader()
-            .valueEquals("X-Content-Type-Options", "nosniff")
-            .expectHeader()
-            .valueEquals("Referrer-Policy", "no-referrer")
-            .expectHeader()
-            .value("Content-Security-Policy") { csp ->
-                require("default-src 'self'" in csp) { "missing default-src: $csp" }
-                require("script-src 'self'" in csp) { "missing script-src: $csp" }
-                require("frame-ancestors 'none'" in csp) { "missing frame-ancestors: $csp" }
-                require("object-src 'none'" in csp) { "missing object-src: $csp" }
-                require("img-src 'self' https: data:" in csp) { "missing img-src: $csp" }
-            }
+class SecurityHeadersFilterContext : SpringTestConfig()
+
+val SecurityHeadersFilterSuite by testSuite {
+    springTest<SecurityHeadersFilterContext> {
+        test("every response carries the security headers") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/")
+                .exchange()
+                .expectHeader()
+                .valueEquals("X-Content-Type-Options", "nosniff")
+                .expectHeader()
+                .valueEquals("Referrer-Policy", "no-referrer")
+                .expectHeader()
+                .value("Content-Security-Policy") { csp ->
+                    require("default-src 'self'" in csp) { "missing default-src: $csp" }
+                    require("script-src 'self'" in csp) { "missing script-src: $csp" }
+                    require("frame-ancestors 'none'" in csp) { "missing frame-ancestors: $csp" }
+                    require("object-src 'none'" in csp) { "missing object-src: $csp" }
+                    require("img-src 'self' https: data:" in csp) { "missing img-src: $csp" }
+                }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
@@ -1,19 +1,18 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 
-class SpaForwardingRouterTest {
-    private val client =
-        WebTestClient
-            .bindToRouterFunction(SpaForwardingRouter().spaRoutes())
-            .build()
-
-    @Test
-    fun `the router is scoped to app and does not match other paths`() {
+val SpaForwardingRouterUnitSuite by testSuite {
+    test("the router is scoped to app and does not match other paths") {
+        val client =
+            WebTestClient
+                .bindToRouterFunction(SpaForwardingRouter().spaRoutes())
+                .build()
         client
             .get()
             .uri("/api/challenges/anything")
@@ -25,28 +24,28 @@ class SpaForwardingRouterTest {
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class SpaForwardingRouterIntegrationTest(
-    @Autowired private val client: WebTestClient,
-) {
-    @Test
-    fun `root redirects to the SPA entry`() {
-        client
-            .get()
-            .uri("/")
-            .exchange()
-            .expectStatus()
-            .isFound
-            .expectHeader()
-            .valueEquals("Location", "/app/")
-    }
+class SpaForwardingRouterContext : SpringTestConfig()
 
-    @Test
-    fun `app deep links are served by the SPA entry point`() {
-        client
-            .get()
-            .uri("/app/some/deep/link")
-            .exchange()
-            .expectStatus()
-            .isOk
+val SpaForwardingRouterIntegrationSuite by testSuite {
+    springTest<SpaForwardingRouterContext> {
+        test("root redirects to the SPA entry") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/")
+                .exchange()
+                .expectStatus()
+                .isFound
+                .expectHeader()
+                .valueEquals("Location", "/app/")
+        }
+
+        test("app deep links are served by the SPA entry point") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/app/some/deep/link")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -1,53 +1,52 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(StartChallengeController::class)
-class StartChallengeControllerTest(
-    @Autowired val client: WebTestClient,
-) {
-    @MockkBean
-    lateinit var startChallenge: StartChallenge
+class StartChallengeWebContext : SpringTestConfig()
 
-    @Test
-    fun `POST creates a challenge and never leaks the prompt`() {
-        coEvery { startChallenge(any()) } returns mediumChallenge()
+val StartChallengeControllerSuite by testSuite {
+    springTest<StartChallengeWebContext> {
+        val startChallenge = mockBean<StartChallenge>()
 
-        client
-            .post()
-            .uri("/api/challenges")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.livesRemaining")
-            .isEqualTo(6)
-            .jsonPath("$.status")
-            .isEqualTo("IN_PROGRESS")
-            .jsonPath("$.picture.status")
-            .isEqualTo("PENDING")
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(false)
-            .jsonPath("$.prompt")
-            .doesNotExist()
-            .jsonPath("$.secretPrompt")
-            .doesNotExist()
-    }
+        test("POST creates a challenge and never leaks the prompt") {
+            coEvery { startChallenge(any()) } returns mediumChallenge()
 
-    @Test
-    fun `invalid difficulty query param returns 422`() {
-        client
-            .post()
-            .uri("/api/challenges?difficulty=NOPE")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.livesRemaining")
+                .isEqualTo(6)
+                .jsonPath("$.status")
+                .isEqualTo("IN_PROGRESS")
+                .jsonPath("$.picture.status")
+                .isEqualTo("PENDING")
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(false)
+                .jsonPath("$.prompt")
+                .doesNotExist()
+                .jsonPath("$.secretPrompt")
+                .doesNotExist()
+        }
+
+        test("invalid difficulty query param returns 422") {
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges?difficulty=NOPE")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -12,82 +12,95 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.CoroutineScope
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class PicturePregenerationTest {
-    private val store = InMemoryChallengeStore()
-    private val storeChallenge = InMemoryStoreChallenge(store)
-    private val findById = InMemoryFindChallengeById(store)
-    private val findPending = InMemoryFindPendingChallenges(store)
-
-    @Test
-    fun `generation flips a pending picture to ready and persists it`() =
+val PicturePregenerationSuite by testSuite {
+    test("generation flips a pending picture to ready and persists it") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = Machine { Picture.Ready("http://img/1.png") }
             val c = storeChallenge(mediumChallenge())
 
             // When
-            pregeneration(machine, this).enqueue(c.id)
+            PicturePregeneration(machine, findById, storeChallenge, findPending, this, 50).enqueue(c.id)
             advanceUntilIdle()
 
             // Then
-            assertEquals(Picture.Ready("http://img/1.png"), findById(c.id)?.picture)
+            findById(c.id)?.picture shouldBe Picture.Ready("http://img/1.png")
         }
+    }
 
-    @Test
-    fun `a failing machine persists a failed picture`() =
+    test("a failing machine persists a failed picture") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = Machine { error("boom") }
             val c = storeChallenge(mediumChallenge())
 
             // When
-            pregeneration(machine, this).enqueue(c.id)
+            PicturePregeneration(machine, findById, storeChallenge, findPending, this, 50).enqueue(c.id)
             advanceUntilIdle()
 
             // Then
-            assertEquals(Picture.Failed, findById(c.id)?.picture)
+            findById(c.id)?.picture shouldBe Picture.Failed
         }
+    }
 
-    @Test
-    fun `enqueue for an unknown challenge is a no-op`() =
+    test("enqueue for an unknown challenge is a no-op") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = Machine { Picture.Ready("http://img/1.png") }
 
             // When
-            pregeneration(machine, this).enqueue(aChallengeId())
+            PicturePregeneration(machine, findById, storeChallenge, findPending, this, 50).enqueue(aChallengeId())
             advanceUntilIdle()
         }
+    }
 
-    @Test
-    fun `retryPending re-enqueues every challenge still awaiting a picture`() =
+    test("retryPending re-enqueues every challenge still awaiting a picture") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = Machine { Picture.Ready("http://img/retry.png") }
             val pending = storeChallenge(mediumChallenge())
             val done = storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/done.png")))
 
             // When
-            pregeneration(machine, this).retryPending()
+            PicturePregeneration(machine, findById, storeChallenge, findPending, this, 50).retryPending()
             advanceUntilIdle()
 
             // Then
-            assertEquals(Picture.Ready("http://img/retry.png"), findById(pending.id)?.picture)
-            assertEquals(Picture.Ready("http://img/done.png"), findById(done.id)?.picture)
+            findById(pending.id)?.picture shouldBe Picture.Ready("http://img/retry.png")
+            findById(done.id)?.picture shouldBe Picture.Ready("http://img/done.png")
         }
+    }
 
-    @Test
-    fun `a concurrent version bump is retried so the picture still persists`() =
+    test("a concurrent version bump is retried so the picture still persists") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val seeded = storeChallenge(mediumChallenge())
 
             var firstStore = true
@@ -103,21 +116,25 @@ class PicturePregenerationTest {
             val machine = Machine { Picture.Ready("http://img/raced.png") }
 
             // When
-            pregeneration(machine, this, racingStore).enqueue(seeded.id)
+            PicturePregeneration(machine, findById, racingStore, findPending, this, 50).enqueue(seeded.id)
             advanceUntilIdle()
 
             // Then
-            assertEquals(Picture.Ready("http://img/raced.png"), findById(seeded.id)?.picture)
+            findById(seeded.id)?.picture shouldBe Picture.Ready("http://img/raced.png")
         }
+    }
 
-    @Test
-    fun `enqueue sheds work once the admission bound is full`() =
+    test("enqueue sheds work once the admission bound is full") {
         runTest {
             // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = Machine { Picture.Ready("http://img/admitted.png") }
             val admitted = storeChallenge(mediumChallenge())
             val shed = storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()))
-            val pregeneration = pregeneration(machine, this, maxQueued = 1)
+            val pregeneration = PicturePregeneration(machine, findById, storeChallenge, findPending, this, 1)
 
             // When
             pregeneration.enqueue(admitted.id)
@@ -125,14 +142,8 @@ class PicturePregenerationTest {
             advanceUntilIdle()
 
             // Then
-            assertEquals(Picture.Ready("http://img/admitted.png"), findById(admitted.id)?.picture)
-            assertEquals(Picture.Pending, findById(shed.id)?.picture)
+            findById(admitted.id)?.picture shouldBe Picture.Ready("http://img/admitted.png")
+            findById(shed.id)?.picture shouldBe Picture.Pending
         }
-
-    private fun pregeneration(
-        machine: Machine,
-        scope: CoroutineScope,
-        store: StoreChallenge = storeChallenge,
-        maxQueued: Int = 50,
-    ) = PicturePregeneration(machine, findById, store, findPending, scope, maxQueued)
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
@@ -2,36 +2,31 @@ package com.yonatankarp.beatthemachine.output.ai
 
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class SeedMachineTest {
-    private val machine = SeedMachine()
+val SeedMachineSuite by testSuite {
+    val machine = SeedMachine()
 
-    @Test
-    fun `returns the curated url for a known prompt`() =
-        runTest {
-            // Given
-            val (prompt, url) = SEED.first()
+    test("returns the curated url for a known prompt") {
+        // Given
+        val (prompt, url) = SEED.first()
 
-            // When
-            val result = machine.generate(prompt)
+        // When
+        val result = machine.generate(prompt)
 
-            // Then
-            assertEquals(Picture.Ready(url), result)
-        }
+        // Then
+        result shouldBe Picture.Ready(url)
+    }
 
-    @Test
-    fun `returns Failed for an unknown prompt`() =
-        runTest {
-            // Given
-            val prompt = "a prompt that is not seeded".asPrompt()
+    test("returns Failed for an unknown prompt") {
+        // Given
+        val prompt = "a prompt that is not seeded".asPrompt()
 
-            // When
-            val result = machine.generate(prompt)
+        // When
+        val result = machine.generate(prompt)
 
-            // Then
-            assertEquals(Picture.Failed, result)
-        }
+        // Then
+        result shouldBe Picture.Failed
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
@@ -1,21 +1,18 @@
 package com.yonatankarp.beatthemachine.output.ai
 
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
 
-class SeedPromptSourceTest {
-    @Test
-    fun `returns a prompt from the curated seed set`() =
-        runTest {
-            // Given
-            val seedPrompts = SEED.map { it.first }.toSet()
+val SeedPromptSourceSuite by testSuite {
+    test("returns a prompt from the curated seed set") {
+        // Given
+        val seedPrompts = SEED.map { it.first }.toSet()
 
-            // When / Then
-            repeat(20) {
-                val prompt = SeedPromptSource().next(Difficulty.MEDIUM)
-                assertTrue(prompt in seedPrompts, "returned prompt must come from the curated SEED set")
-            }
+        // When / Then
+        repeat(20) {
+            val prompt = SeedPromptSource().next(Difficulty.MEDIUM)
+            (prompt in seedPrompts).shouldBeTrue()
         }
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -2,40 +2,35 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 
-class InMemoryFindChallengeByIdTest {
-    @Test
-    fun `finds a stored challenge`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findChallengeById = InMemoryFindChallengeById(store)
-            val saved = storeChallenge(mediumChallenge())
+val InMemoryFindChallengeByIdSuite by testSuite {
+    test("finds a stored challenge") {
+        // Given
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val findChallengeById = InMemoryFindChallengeById(store)
+        val saved = storeChallenge(mediumChallenge())
 
-            // When
-            val found = findChallengeById(saved.id)
+        // When
+        val found = findChallengeById(saved.id)
 
-            // Then
-            assertEquals(saved.id, found?.id)
-        }
+        // Then
+        found?.id shouldBe saved.id
+    }
 
-    @Test
-    fun `returns null for an unknown id`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val findChallengeById = InMemoryFindChallengeById(store)
-            val unknownId = aChallengeId()
+    test("returns null for an unknown id") {
+        // Given
+        val store = InMemoryChallengeStore()
+        val findChallengeById = InMemoryFindChallengeById(store)
+        val unknownId = aChallengeId()
 
-            // When
-            val found = findChallengeById(unknownId)
+        // When
+        val found = findChallengeById(unknownId)
 
-            // Then
-            assertNull(found)
-        }
+        // Then
+        found.shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -3,26 +3,23 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class InMemoryFindPendingChallengesTest {
-    @Test
-    fun `returns only challenges whose picture is pending`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findPendingChallenges = InMemoryFindPendingChallenges(store)
-            val pendingA = storeChallenge(mediumChallenge())
-            val pendingB = storeChallenge(mediumChallenge(prompt = "red fox".asPrompt()))
-            storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
+val InMemoryFindPendingChallengesSuite by testSuite {
+    test("returns only challenges whose picture is pending") {
+        // Given
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val findPendingChallenges = InMemoryFindPendingChallenges(store)
+        val pendingA = storeChallenge(mediumChallenge())
+        val pendingB = storeChallenge(mediumChallenge(prompt = "red fox".asPrompt()))
+        storeChallenge(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
 
-            // When
-            val ids = findPendingChallenges().map { it.id }.toSet()
+        // When
+        val ids = findPendingChallenges().map { it.id }.toSet()
 
-            // Then
-            assertEquals(setOf(pendingA.id, pendingB.id), ids)
-        }
+        // Then
+        ids shouldBe setOf(pendingA.id, pendingB.id)
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -2,37 +2,32 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class InMemoryStoreChallengeTest {
-    @Test
-    fun `stores and bumps the version`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val challenge = mediumChallenge()
+val InMemoryStoreChallengeTestSuite by testSuite {
+    test("stores and bumps the version") {
+        // Given
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val challenge = mediumChallenge()
 
-            // When
-            val saved = storeChallenge(challenge)
+        // When
+        val saved = storeChallenge(challenge)
 
-            // Then
-            assertEquals(1L, saved.version)
-        }
+        // Then
+        saved.version shouldBe 1L
+    }
 
-    @Test
-    fun `rejects a stale version`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val c = mediumChallenge()
-            storeChallenge(c)
+    test("rejects a stale version") {
+        // Given
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val c = mediumChallenge()
+        storeChallenge(c)
 
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> { storeChallenge(c) }
-        }
+        // When / Then
+        shouldThrow<OptimisticLockConflict> { storeChallenge(c) }
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIT.kt
@@ -4,52 +4,31 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 
-class SqliteFindChallengeByIdIT {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findChallengeById: SqliteFindChallengeById
+val SqliteFindChallengeByIdITSuite by testSuite {
+    test("finds a stored challenge with its fields intact") {
+        val (storeChallenge, findChallengeById, _) = newSqliteAdapters()
+        val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
+        storeChallenge(c)
 
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findChallengeById = SqliteFindChallengeById(jdbc, mapper)
+        val found = findChallengeById(c.id)
+
+        found.shouldNotBeNull()
+        found.id shouldBe c.id
+        found.secretPrompt().text shouldBe "pixel art cat"
+        found.lives.remaining shouldBe 5
     }
 
-    @Test
-    fun `finds a stored challenge with its fields intact`() =
-        runTest {
-            // Given
-            val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
-            storeChallenge(c)
+    test("returns null for an unknown id") {
+        val (_, findChallengeById, _) = newSqliteAdapters()
+        val unknownId = aChallengeId()
 
-            // When
-            val found = findChallengeById(c.id)
+        val found = findChallengeById(unknownId)
 
-            // Then
-            assertNotNull(found)
-            assertEquals(c.id, found.id)
-            assertEquals("pixel art cat", found.secretPrompt().text)
-            assertEquals(5, found.lives.remaining)
-        }
-
-    @Test
-    fun `returns null for an unknown id`() =
-        runTest {
-            // Given
-            val unknownId = aChallengeId()
-
-            // When
-            val found = findChallengeById(unknownId)
-
-            // Then
-            assertNull(found)
-        }
+        found.shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIT.kt
@@ -4,36 +4,19 @@ import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class SqliteFindPendingChallengesIT {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findPendingChallenges: SqliteFindPendingChallenges
+val SqliteFindPendingChallengesITSuite by testSuite {
+    test("returns only challenges whose picture is pending") {
+        val (storeChallenge, _, findPendingChallenges) = newSqliteAdapters()
+        val pendingA = storeChallenge(mediumChallenge(prompt = "pending one".asPrompt()))
+        val pendingB = storeChallenge(mediumChallenge(prompt = "pending two".asPrompt()))
+        storeChallenge(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
+        storeChallenge(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
 
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findPendingChallenges = SqliteFindPendingChallenges(jdbc, mapper)
+        val ids = findPendingChallenges().map { it.id }.toSet()
+
+        ids shouldBe setOf(pendingA.id, pendingB.id)
     }
-
-    @Test
-    fun `returns only challenges whose picture is pending`() =
-        runTest {
-            // Given
-            val pendingA = storeChallenge(mediumChallenge(prompt = "pending one".asPrompt()))
-            val pendingB = storeChallenge(mediumChallenge(prompt = "pending two".asPrompt()))
-            storeChallenge(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
-            storeChallenge(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
-
-            // When
-            val ids = findPendingChallenges().map { it.id }.toSet()
-
-            // Then
-            assertEquals(setOf(pendingA.id, pendingB.id), ids)
-        }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIT.kt
@@ -9,96 +9,64 @@ import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 
-class SqliteStoreChallengeIT {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findChallengeById: SqliteFindChallengeById
+val SqliteStoreChallengeITSuite by testSuite {
+    test("stores a fresh challenge and bumps the version") {
+        val (storeChallenge, _, _) = newSqliteAdapters()
+        val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
 
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findChallengeById = SqliteFindChallengeById(jdbc, mapper)
+        val saved = storeChallenge(challenge)
+
+        saved.version shouldBe 1L
     }
 
-    @Test
-    fun `stores a fresh challenge and bumps the version`() =
-        runTest {
-            // Given
-            val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
+    test("allows sequential stores with updated versions") {
+        val (storeChallenge, _, _) = newSqliteAdapters()
+        val challenge = mediumChallenge(prompt = "sequential".asPrompt())
 
-            // When
-            val saved = storeChallenge(challenge)
+        val v1 = storeChallenge(challenge)
+        val v2 = storeChallenge(v1)
 
-            // Then
-            assertEquals(1L, saved.version)
-        }
+        v1.version shouldBe 1L
+        v2.version shouldBe 2L
+    }
 
-    @Test
-    fun `allows sequential stores with updated versions`() =
-        runTest {
-            // Given
-            val challenge = mediumChallenge(prompt = "sequential".asPrompt())
+    test("rejects a stale version on second store") {
+        val (storeChallenge, _, _) = newSqliteAdapters()
+        val c = mediumChallenge()
+        storeChallenge(c)
 
-            // When
-            val v1 = storeChallenge(challenge)
-            val v2 = storeChallenge(v1)
+        shouldThrow<OptimisticLockConflict> { storeChallenge(c) }
+    }
 
-            // Then
-            assertEquals(1L, v1.version)
-            assertEquals(2L, v2.version)
-        }
+    test("persists all difficulty levels") {
+        val (storeChallenge, findChallengeById, _) = newSqliteAdapters()
 
-    @Test
-    fun `rejects a stale version on second store`() =
-        runTest {
-            // Given
-            val c = mediumChallenge()
+        Difficulty.entries.forEach { diff ->
+            val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
             storeChallenge(c)
-
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> { storeChallenge(c) }
+            val found = findChallengeById(c.id)
+            found.shouldNotBeNull()
+            found.difficulty shouldBe diff
         }
+    }
 
-    @Test
-    fun `persists all difficulty levels`() =
-        runTest {
-            // Given
-            val difficulties = Difficulty.entries
+    test("persists picture states correctly") {
+        val (storeChallenge, findChallengeById, _) = newSqliteAdapters()
+        val pending = mediumChallenge(prompt = "pending pic".asPrompt())
+        val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
+        val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
 
-            // When / Then
-            difficulties.forEach { diff ->
-                val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
-                storeChallenge(c)
-                val found = findChallengeById(c.id)
-                assertNotNull(found)
-                assertEquals(diff, found.difficulty)
-            }
-        }
+        storeChallenge(pending)
+        storeChallenge(ready)
+        storeChallenge(failed)
 
-    @Test
-    fun `persists picture states correctly`() =
-        runTest {
-            // Given
-            val pending = mediumChallenge(prompt = "pending pic".asPrompt())
-            val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
-            val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
-
-            // When
-            storeChallenge(pending)
-            storeChallenge(ready)
-            storeChallenge(failed)
-
-            // Then
-            assertEquals(Picture.Pending, findChallengeById(pending.id)?.picture)
-            assertEquals(Picture.Ready("https://example.com/img.png"), findChallengeById(ready.id)?.picture)
-            assertEquals(Picture.Failed, findChallengeById(failed.id)?.picture)
-        }
+        findChallengeById(pending.id)?.picture shouldBe Picture.Pending
+        findChallengeById(ready.id)?.picture shouldBe Picture.Ready("https://example.com/img.png")
+        findChallengeById(failed.id)?.picture shouldBe Picture.Failed
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
@@ -19,3 +19,19 @@ internal fun newSqliteJdbc(): JdbcTemplate {
         .forEach { jdbc.execute(it) }
     return jdbc
 }
+
+internal data class SqliteAdapters(
+    val storeChallenge: SqliteStoreChallenge,
+    val findChallengeById: SqliteFindChallengeById,
+    val findPendingChallenges: SqliteFindPendingChallenges,
+)
+
+internal fun newSqliteAdapters(): SqliteAdapters {
+    val jdbc = newSqliteJdbc()
+    val mapper = ChallengeRowMapper()
+    return SqliteAdapters(
+        SqliteStoreChallenge(jdbc, mapper),
+        SqliteFindChallengeById(jdbc, mapper),
+        SqliteFindPendingChallenges(jdbc, mapper),
+    )
+}

--- a/beat-the-machine-application/build.gradle.kts
+++ b/beat-the-machine-application/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jacoco
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.testballoon)
 }
 
 kotlin {
@@ -16,6 +17,18 @@ dependencies {
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.withType<Test> {

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -5,41 +5,34 @@ import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class ForfeitChallengeUseCaseTest {
-    private val store = FakeChallengeStore()
+val ForfeitChallengeUseCaseSuite by testSuite {
+    test("forfeit loads the challenge, sets LOST, and persists it") {
+        // Given
+        val store = FakeChallengeStore() // mutable: fresh per test
+        val c: Challenge = store(mediumChallenge())
+        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
 
-    private suspend fun seed(): Challenge = store(mediumChallenge())
+        // When
+        val result = forfeitChallenge(c.id)
 
-    @Test
-    fun `forfeit loads the challenge, sets LOST, and persists it`() =
-        runTest {
-            // Given
-            val c = seed()
-            val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+        // Then
+        result.status shouldBe ChallengeStatus.LOST
+        store(c.id)?.status shouldBe ChallengeStatus.LOST
+    }
 
-            // When
-            val result = forfeitChallenge(c.id)
+    test("an unknown challenge throws ChallengeNotFound") {
+        // Given
+        val store = FakeChallengeStore()
+        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+        val unknownId = aChallengeId()
 
-            // Then
-            assertEquals(ChallengeStatus.LOST, result.status)
-            assertEquals(ChallengeStatus.LOST, store(c.id)?.status)
+        // When / Then
+        shouldThrow<ChallengeNotFound> {
+            forfeitChallenge(unknownId)
         }
-
-    @Test
-    fun `an unknown challenge throws ChallengeNotFound`() =
-        runTest {
-            // Given
-            val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-            val unknownId = aChallengeId()
-
-            // When / Then
-            assertFailsWith<ChallengeNotFound> {
-                forfeitChallenge(unknownId)
-            }
-        }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -4,35 +4,31 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class GetChallengeUseCaseTest {
-    private val store = FakeChallengeStore()
-    private val getChallenge = GetChallengeUseCase(store)
+val GetChallengeUseCaseSuite by testSuite {
+    test("returns a challenge that exists") {
+        // Given
+        val store = FakeChallengeStore() // mutable: fresh per test
+        val getChallenge = GetChallengeUseCase(store)
+        val challenge = store(mediumChallenge(prompt = "red fox".asPrompt()))
 
-    @Test
-    fun `returns a challenge that exists`() =
-        runTest {
-            // Given
-            val challenge = store(mediumChallenge(prompt = "red fox".asPrompt()))
+        // When
+        val result = getChallenge(challenge.id)
 
-            // When
-            val result = getChallenge(challenge.id)
+        // Then
+        result shouldBe challenge
+    }
 
-            // Then
-            assertEquals(challenge, result)
-        }
+    test("throws ChallengeNotFound for an unknown id") {
+        // Given
+        val store = FakeChallengeStore()
+        val getChallenge = GetChallengeUseCase(store)
+        val unknownId = aChallengeId()
 
-    @Test
-    fun `throws ChallengeNotFound for an unknown id`() =
-        runTest {
-            // Given
-            val unknownId = aChallengeId()
-
-            // When / Then
-            assertFailsWith<ChallengeNotFound> { getChallenge(unknownId) }
-        }
+        // When / Then
+        shouldThrow<ChallengeNotFound> { getChallenge(unknownId) }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -9,59 +9,51 @@ import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class MakeGuessUseCaseTest {
-    private val store = FakeChallengeStore()
+val MakeGuessUseCaseSuite by testSuite {
+    test("a hit is persisted") {
+        // Given
+        val store = FakeChallengeStore() // mutable: fresh per test
+        val c: Challenge = store(mediumChallenge())
+        val makeGuess = MakeGuessUseCase(store, store)
+        val guess = "hello".asGuess()
 
-    private suspend fun seed(): Challenge = store(mediumChallenge())
+        // When
+        val (updated, outcome) = makeGuess(c.id, guess)
 
-    @Test
-    fun `a hit is persisted`() =
-        runTest {
-            // Given
-            val c = seed()
-            val makeGuess = MakeGuessUseCase(store, store)
-            val guess = "hello".asGuess()
+        // Then
+        outcome shouldBe GuessOutcome.HIT
+        updated.maskedPrompt().tokens[0] shouldBe MaskedToken.Revealed("hello")
+        store(c.id)?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
+    }
 
-            // When
-            val (updated, outcome) = makeGuess(c.id, guess)
+    test("an unknown challenge throws ChallengeNotFound") {
+        // Given
+        val store = FakeChallengeStore()
+        val makeGuess = MakeGuessUseCase(store, store)
+        val unknownId = aChallengeId()
+        val guess = "hello".asGuess()
 
-            // Then
-            assertEquals(GuessOutcome.HIT, outcome)
-            assertEquals(MaskedToken.Revealed("hello"), updated.maskedPrompt().tokens[0])
-            assertEquals(MaskedToken.Revealed("hello"), store(c.id)?.maskedPrompt()?.tokens?.get(0))
+        // When / Then
+        shouldThrow<ChallengeNotFound> {
+            makeGuess(unknownId, guess)
         }
+    }
 
-    @Test
-    fun `an unknown challenge throws ChallengeNotFound`() =
-        runTest {
-            // Given
-            val makeGuess = MakeGuessUseCase(store, store)
-            val unknownId = aChallengeId()
-            val guess = "hello".asGuess()
+    test("an optimistic-lock conflict on store propagates") {
+        // Given
+        val store = FakeChallengeStore()
+        val c: Challenge = store(mediumChallenge())
+        val conflicting = StoreChallenge { throw OptimisticLockConflict(it.id) }
+        val makeGuess = MakeGuessUseCase(store, conflicting)
+        val guess = "hello".asGuess()
 
-            // When / Then
-            assertFailsWith<ChallengeNotFound> {
-                makeGuess(unknownId, guess)
-            }
+        // When / Then
+        shouldThrow<OptimisticLockConflict> {
+            makeGuess(c.id, guess)
         }
-
-    @Test
-    fun `an optimistic-lock conflict on store propagates`() =
-        runTest {
-            // Given
-            val c = seed()
-            val conflicting = StoreChallenge { throw OptimisticLockConflict(it.id) }
-            val makeGuess = MakeGuessUseCase(store, conflicting)
-            val guess = "hello".asGuess()
-
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> {
-                makeGuess(c.id, guess)
-            }
-        }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -6,46 +6,42 @@ import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class StartChallengeUseCaseTest {
-    private val prompts = PromptSource { "hello world".asPrompt() }
-    private val store = FakeChallengeStore()
+val StartChallengeUseCaseSuite by testSuite {
+    val prompts = PromptSource { "hello world".asPrompt() } // stateless, safe at suite scope
 
-    @Test
-    fun `starts a pending challenge and enqueues picture generation`() =
-        runTest {
-            // Given
-            val enqueued = mutableListOf<ChallengeId>()
-            val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
+    test("starts a pending challenge and enqueues picture generation") {
+        // Given
+        val store = FakeChallengeStore() // mutable: fresh per test
+        val enqueued = mutableListOf<ChallengeId>()
+        val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
 
-            // When
-            val challenge = startChallenge(Difficulty.MEDIUM)
+        // When
+        val challenge = startChallenge(Difficulty.MEDIUM)
 
-            // Then
-            assertEquals(Picture.Pending, challenge.picture)
-            assertEquals(ChallengeStatus.IN_PROGRESS, challenge.status)
-            assertEquals(listOf(challenge.id), enqueued)
-            assertTrue(store.byId.containsKey(challenge.id))
-        }
+        // Then
+        challenge.picture shouldBe Picture.Pending
+        challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+        enqueued shouldBe listOf(challenge.id)
+        store.byId.containsKey(challenge.id).shouldBeTrue()
+    }
 
-    @Test
-    fun `starting lives scale with difficulty`() =
-        runTest {
-            // Given
-            val startChallenge = StartChallengeUseCase(prompts, store) {}
+    test("starting lives scale with difficulty") {
+        // Given
+        val store = FakeChallengeStore()
+        val startChallenge = StartChallengeUseCase(prompts, store) {}
 
-            // When
-            val easy = startChallenge(Difficulty.EASY)
-            val medium = startChallenge(Difficulty.MEDIUM)
-            val hard = startChallenge(Difficulty.HARD)
+        // When
+        val easy = startChallenge(Difficulty.EASY)
+        val medium = startChallenge(Difficulty.MEDIUM)
+        val hard = startChallenge(Difficulty.HARD)
 
-            // Then
-            assertEquals(8, easy.lives.remaining)
-            assertEquals(6, medium.lives.remaining)
-            assertEquals(4, hard.lives.remaining)
-        }
+        // Then
+        easy.lives.remaining shouldBe 8
+        medium.lives.remaining shouldBe 6
+        hard.lives.remaining shouldBe 4
+    }
 }

--- a/beat-the-machine-domain/build.gradle.kts
+++ b/beat-the-machine-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jacoco
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.testballoon)
     `java-test-fixtures`
 }
 
@@ -12,6 +13,18 @@ kotlin {
 
 dependencies {
     testImplementation(libs.bundles.unit.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.withType<Test> {

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -9,15 +9,13 @@ import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotSame
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class ChallengeTest {
-    @Test
-    fun `a correct guess reveals the word and stays in progress`() {
+val ChallengeSuite by testSuite {
+    test("a correct guess reveals the word and stays in progress") {
         // Given
         val challenge = mediumChallenge(lives = 3.lives())
         val guess = "hello".asGuess()
@@ -26,13 +24,12 @@ class ChallengeTest {
         val (updated, outcome) = challenge.makeGuess(guess)
 
         // Then
-        assertEquals(GuessOutcome.HIT, outcome)
-        assertEquals(ChallengeStatus.IN_PROGRESS, updated.status)
-        assertEquals(3, updated.lives.remaining)
+        outcome shouldBe GuessOutcome.HIT
+        updated.status shouldBe ChallengeStatus.IN_PROGRESS
+        updated.lives.remaining shouldBe 3
     }
 
-    @Test
-    fun `a wrong guess costs a life`() {
+    test("a wrong guess costs a life") {
         // Given
         val challenge = mediumChallenge(lives = 3.lives())
         val guess = "nope".asGuess()
@@ -41,12 +38,11 @@ class ChallengeTest {
         val (updated, outcome) = challenge.makeGuess(guess)
 
         // Then
-        assertEquals(GuessOutcome.MISS, outcome)
-        assertEquals(2, updated.lives.remaining)
+        outcome shouldBe GuessOutcome.MISS
+        updated.lives.remaining shouldBe 2
     }
 
-    @Test
-    fun `guessing every word beats the machine`() {
+    test("guessing every word beats the machine") {
         // Given
         val challenge = mediumChallenge()
         val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
@@ -55,12 +51,11 @@ class ChallengeTest {
         val (afterSecond, outcome) = afterFirst.makeGuess("world".asGuess())
 
         // Then
-        assertEquals(GuessOutcome.HIT, outcome)
-        assertEquals(ChallengeStatus.BEATEN, afterSecond.status)
+        outcome shouldBe GuessOutcome.HIT
+        afterSecond.status shouldBe ChallengeStatus.BEATEN
     }
 
-    @Test
-    fun `running out of lives loses the challenge`() {
+    test("running out of lives loses the challenge") {
         // Given
         val challenge = mediumChallenge(lives = 1.lives())
         val guess = "nope".asGuess()
@@ -69,11 +64,10 @@ class ChallengeTest {
         val (updated, _) = challenge.makeGuess(guess)
 
         // Then
-        assertEquals(ChallengeStatus.LOST, updated.status)
+        updated.status shouldBe ChallengeStatus.LOST
     }
 
-    @Test
-    fun `a duplicate guess is a no-op and costs no life`() {
+    test("a duplicate guess is a no-op and costs no life") {
         // Given
         val challenge = mediumChallenge(lives = 3.lives())
         val (afterFirst, _) = challenge.makeGuess("nope".asGuess())
@@ -82,12 +76,11 @@ class ChallengeTest {
         val (afterSecond, outcome) = afterFirst.makeGuess("Nope".asGuess())
 
         // Then
-        assertEquals(GuessOutcome.DUPLICATE, outcome)
-        assertEquals(2, afterSecond.lives.remaining)
+        outcome shouldBe GuessOutcome.DUPLICATE
+        afterSecond.lives.remaining shouldBe 2
     }
 
-    @Test
-    fun `makeGuess does not mutate the receiver`() {
+    test("makeGuess does not mutate the receiver") {
         // Given
         val challenge = mediumChallenge(lives = 3.lives())
         val guess = "nope".asGuess()
@@ -96,21 +89,19 @@ class ChallengeTest {
         challenge.makeGuess(guess)
 
         // Then
-        assertEquals(3, challenge.lives.remaining)
-        assertTrue(challenge.guesses.isEmpty())
+        challenge.lives.remaining shouldBe 3
+        challenge.guesses.isEmpty().shouldBeTrue()
     }
 
-    @Test
-    fun `guessing after the challenge is over is rejected`() {
+    test("guessing after the challenge is over is rejected") {
         // Given
         val (lost, _) = mediumChallenge(lives = 1.lives()).makeGuess("nope".asGuess())
 
         // When / Then
-        assertFailsWith<ChallengeAlreadyOver> { lost.makeGuess("hello".asGuess()) }
+        shouldThrow<ChallengeAlreadyOver> { lost.makeGuess("hello".asGuess()) }
     }
 
-    @Test
-    fun `forfeit reveals the prompt and loses`() {
+    test("forfeit reveals the prompt and loses") {
         // Given
         val challenge = mediumChallenge()
 
@@ -118,21 +109,23 @@ class ChallengeTest {
         val forfeited = challenge.forfeit()
 
         // Then
-        assertEquals(ChallengeStatus.LOST, forfeited.status)
-        assertTrue(forfeited.maskedPrompt().tokens.all { it is MaskedToken.Revealed })
+        forfeited.status shouldBe ChallengeStatus.LOST
+        forfeited
+            .maskedPrompt()
+            .tokens
+            .all { it is MaskedToken.Revealed }
+            .shouldBeTrue()
     }
 
-    @Test
-    fun `forfeit after the challenge is over is rejected`() {
+    test("forfeit after the challenge is over is rejected") {
         // Given
         val forfeited = mediumChallenge().forfeit()
 
         // When / Then
-        assertFailsWith<ChallengeAlreadyOver> { forfeited.forfeit() }
+        shouldThrow<ChallengeAlreadyOver> { forfeited.forfeit() }
     }
 
-    @Test
-    fun `withPicture returns an independent copy at the same version`() {
+    test("withPicture returns an independent copy at the same version") {
         // Given
         val challenge = mediumChallenge()
         val newPicture = readyPicture("https://example.com/img.png")
@@ -141,9 +134,9 @@ class ChallengeTest {
         val updated = challenge.withPicture(newPicture)
 
         // Then
-        assertEquals(newPicture, updated.picture)
-        assertEquals(challenge.version, updated.version)
-        assertEquals(Picture.Pending, challenge.picture)
-        assertNotSame(challenge, updated)
+        updated.picture shouldBe newPicture
+        updated.version shouldBe challenge.version
+        challenge.picture shouldBe Picture.Pending
+        (challenge !== updated).shouldBeTrue()
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
@@ -1,31 +1,28 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
 import com.yonatankarp.beatthemachine.domain.exception.InvalidGuess
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class GuessTest {
-    @Test
-    fun `rejects blank word`() {
+val GuessSuite by testSuite {
+    test("rejects blank word") {
         // Given
         val word = "   "
 
         // When / Then
-        assertFailsWith<InvalidGuess> { Guess(word) }
+        shouldThrow<InvalidGuess> { Guess(word) }
     }
 
-    @Test
-    fun `rejects empty word`() {
+    test("rejects empty word") {
         // Given
         val word = ""
 
         // When / Then
-        assertFailsWith<InvalidGuess> { Guess(word) }
+        shouldThrow<InvalidGuess> { Guess(word) }
     }
 
-    @Test
-    fun `normalized trims and lowercases`() {
+    test("normalized trims and lowercases") {
         // Given
         val guess = Guess("Hello")
 
@@ -33,6 +30,6 @@ class GuessTest {
         val normalized = guess.normalized()
 
         // Then
-        assertEquals("hello", normalized)
+        normalized shouldBe "hello"
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
@@ -1,23 +1,21 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class LivesTest {
-    @Test
-    fun `cannot be negative`() {
+val LivesSuite by testSuite {
+    test("cannot be negative") {
         // Given
         val count = -1
 
         // When / Then
-        assertFailsWith<IllegalArgumentException> { Lives(count) }
+        shouldThrow<IllegalArgumentException> { Lives(count) }
     }
 
-    @Test
-    fun `lose decrements and floors at zero`() {
+    test("lose decrements and floors at zero") {
         // Given
         val oneLife = Lives(1)
         val noLives = Lives(0)
@@ -27,12 +25,11 @@ class LivesTest {
         val afterLosingFromZero = noLives.lose()
 
         // Then
-        assertEquals(Lives(0), afterLosingFromOne)
-        assertEquals(Lives(0), afterLosingFromZero)
+        afterLosingFromOne shouldBe Lives(0)
+        afterLosingFromZero shouldBe Lives(0)
     }
 
-    @Test
-    fun `is exhausted at zero`() {
+    test("is exhausted at zero") {
         // Given
         val noLives = Lives(0)
         val oneLife = Lives(1)
@@ -42,20 +39,19 @@ class LivesTest {
         val notExhausted = oneLife.isExhausted()
 
         // Then
-        assertTrue(exhausted)
-        assertFalse(notExhausted)
+        exhausted.shouldBeTrue()
+        notExhausted.shouldBeFalse()
     }
 
-    @Test
-    fun `initial lives are granted per difficulty`() {
+    test("initial lives are granted per difficulty") {
         // When
         val easy = Lives.initialFor(Difficulty.EASY)
         val medium = Lives.initialFor(Difficulty.MEDIUM)
         val hard = Lives.initialFor(Difficulty.HARD)
 
         // Then
-        assertEquals(Lives(8), easy)
-        assertEquals(Lives(6), medium)
-        assertEquals(Lives(4), hard)
+        easy shouldBe Lives(8)
+        medium shouldBe Lives(6)
+        hard shouldBe Lives(4)
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
@@ -2,14 +2,13 @@ package com.yonatankarp.beatthemachine.domain.valueobject
 
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class MaskedPromptTest {
-    @Test
-    fun `hides every word when there are no guesses`() {
+val MaskedPromptSuite by testSuite {
+    test("hides every word when there are no guesses") {
         // Given
         val secret = "hello world".asPrompt()
         val guesses = emptySet<Guess>()
@@ -18,12 +17,11 @@ class MaskedPromptTest {
         val masked = MaskedPrompt.of(secret, guesses)
 
         // Then
-        assertEquals(listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5)), masked.tokens)
-        assertFalse(masked.isFullyRevealed())
+        masked.tokens shouldBe listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5))
+        masked.isFullyRevealed().shouldBeFalse()
     }
 
-    @Test
-    fun `reveals a matching word case-insensitively`() {
+    test("reveals a matching word case-insensitively") {
         // Given
         val secret = "Hello World".asPrompt()
         val guesses = setOf("hello".asGuess())
@@ -32,12 +30,11 @@ class MaskedPromptTest {
         val masked = MaskedPrompt.of(secret, guesses)
 
         // Then
-        assertEquals(MaskedToken.Revealed("Hello"), masked.tokens[0])
-        assertEquals(MaskedToken.Hidden(5), masked.tokens[1])
+        masked.tokens[0] shouldBe MaskedToken.Revealed("Hello")
+        masked.tokens[1] shouldBe MaskedToken.Hidden(5)
     }
 
-    @Test
-    fun `reveals every occurrence of a repeated word`() {
+    test("reveals every occurrence of a repeated word") {
         // Given
         val secret = "na na batman".asPrompt()
         val guesses = setOf("na".asGuess())
@@ -46,14 +43,10 @@ class MaskedPromptTest {
         val masked = MaskedPrompt.of(secret, guesses)
 
         // Then
-        assertEquals(
-            listOf(MaskedToken.Revealed("na"), MaskedToken.Revealed("na"), MaskedToken.Hidden(6)),
-            masked.tokens,
-        )
+        masked.tokens shouldBe listOf(MaskedToken.Revealed("na"), MaskedToken.Revealed("na"), MaskedToken.Hidden(6))
     }
 
-    @Test
-    fun `collapses arbitrary whitespace using one rule`() {
+    test("collapses arbitrary whitespace using one rule") {
         // Given
         val secret = "hello\t \nworld".asPrompt()
         val guesses = setOf("world".asGuess())
@@ -62,12 +55,11 @@ class MaskedPromptTest {
         val masked = MaskedPrompt.of(secret, guesses)
 
         // Then
-        assertEquals(2, masked.tokens.size)
-        assertEquals(MaskedToken.Revealed("world"), masked.tokens[1])
+        masked.tokens.size shouldBe 2
+        masked.tokens[1] shouldBe MaskedToken.Revealed("world")
     }
 
-    @Test
-    fun `is fully revealed when all words are guessed`() {
+    test("is fully revealed when all words are guessed") {
         // Given
         val secret = "hello world".asPrompt()
         val guesses = setOf("hello".asGuess(), "world".asGuess())
@@ -76,6 +68,6 @@ class MaskedPromptTest {
         val masked = MaskedPrompt.of(secret, guesses)
 
         // Then
-        assertTrue(masked.isFullyRevealed())
+        masked.isFullyRevealed().shouldBeTrue()
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PictureTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PictureTest.kt
@@ -1,21 +1,19 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertIs
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 
-class PictureTest {
-    @Test
-    fun `Pending is a Picture`() {
+val PictureSuite by testSuite {
+    test("Pending is a Picture") {
         // When
         val picture = Picture.Pending
 
         // Then
-        assertIs<Picture.Pending>(picture)
+        picture.shouldBeInstanceOf<Picture.Pending>()
     }
 
-    @Test
-    fun `Ready carries url`() {
+    test("Ready carries url") {
         // Given
         val url = "https://example.com/img.png"
 
@@ -23,16 +21,15 @@ class PictureTest {
         val pic = Picture.Ready(url)
 
         // Then
-        assertIs<Picture.Ready>(pic)
-        assertEquals("https://example.com/img.png", pic.url)
+        pic.shouldBeInstanceOf<Picture.Ready>()
+        pic.url shouldBe "https://example.com/img.png"
     }
 
-    @Test
-    fun `Failed is a Picture`() {
+    test("Failed is a Picture") {
         // When
         val picture = Picture.Failed
 
         // Then
-        assertIs<Picture.Failed>(picture)
+        picture.shouldBeInstanceOf<Picture.Failed>()
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
@@ -1,12 +1,11 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class PromptTest {
-    @Test
-    fun `splits on single space`() {
+val PromptSuite by testSuite {
+    test("splits on single space") {
         // Given
         val prompt = Prompt("hello world")
 
@@ -14,11 +13,10 @@ class PromptTest {
         val words = prompt.words()
 
         // Then
-        assertEquals(listOf("hello", "world"), words)
+        words shouldBe listOf("hello", "world")
     }
 
-    @Test
-    fun `splits on multiple whitespace characters`() {
+    test("splits on multiple whitespace characters") {
         // Given
         val prompt = Prompt("a\t b\n c")
 
@@ -26,24 +24,22 @@ class PromptTest {
         val words = prompt.words()
 
         // Then
-        assertEquals(listOf("a", "b", "c"), words)
+        words shouldBe listOf("a", "b", "c")
     }
 
-    @Test
-    fun `rejects blank text`() {
+    test("rejects blank text") {
         // Given
         val text = "   "
 
         // When / Then
-        assertFailsWith<IllegalArgumentException> { Prompt(text) }
+        shouldThrow<IllegalArgumentException> { Prompt(text) }
     }
 
-    @Test
-    fun `rejects empty text`() {
+    test("rejects empty text") {
         // Given
         val text = ""
 
         // When / Then
-        assertFailsWith<IllegalArgumentException> { Prompt(text) }
+        shouldThrow<IllegalArgumentException> { Prompt(text) }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,12 @@ plugins {
 subprojects {
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/yonatankarp/testballoon-spring")
+            credentials {
+                username = (findProperty("gpr.user") as String?) ?: System.getenv("GITHUB_ACTOR")
+                password = (findProperty("gpr.key") as String?) ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
 openapiContracts = "0.1.0"
 mockk = "1.14.11"
-springmockk = "5.0.1"
 jvm = "25"
 # Matches the version managed by Spring Boot 4.1.0's BOM (kotlinx-coroutines-bom).
 # Pinned here for the application module, which has no Spring dependency management.
@@ -32,11 +31,9 @@ kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
 
 # --- Explicitly versioned (not on the BOM, or used where the BOM is absent) ---
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
 testballoon-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
 testballoon-spring = { module = "com.yonatankarp:testballoon-spring", version = "0.1.1" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
@@ -62,7 +59,6 @@ unit-test = [
     "kotest-assertions-core",
     "mockk",
     "mockwebserver",
-    "kotlin-test",
 ]
 # Spring slice/integration testing plus the testballoon-spring bridge.
 spring-boot-test = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,10 @@ jvm = "25"
 # Matches the version managed by Spring Boot 4.1.0's BOM (kotlinx-coroutines-bom).
 # Pinned here for the application module, which has no Spring dependency management.
 kotlinx-coroutines = "1.11.0"
+testballoon = "1.0.1-K2.4.0"
+kotest = "6.0.3"
+junit-platform-launcher = "1.14.4"
+mockwebserver = "4.12.0"
 
 [libraries]
 # --- Versions managed by Spring Boot's BOM (no version declared here) ---
@@ -33,6 +37,11 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
+testballoon-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
+testballoon-spring = { module = "com.yonatankarp:testballoon-spring", version = "0.1.1" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform-launcher" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 
 [bundles]
 # Production Spring Boot starters used by the adapters module.
@@ -49,14 +58,16 @@ kotlinx-coroutines = [
 ]
 # Plain unit-testing stack shared by every module.
 unit-test = [
-    "kotlin-test",
+    "testballoon-core",
+    "kotest-assertions-core",
     "mockk",
+    "mockwebserver",
+    "kotlin-test",
 ]
-# Spring slice/integration testing plus the springmockk @MockkBean bridge.
+# Spring slice/integration testing plus the testballoon-spring bridge.
 spring-boot-test = [
-    "spring-boot-starter-test",
     "spring-boot-starter-webflux-test",
-    "springmockk",
+    "testballoon-spring",
 ]
 
 [plugins]
@@ -67,3 +78,4 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 openapi-contracts = { id = "com.yonatankarp.openapi.contracts", version.ref = "openapiContracts" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
+testballoon = { id = "de.infix.testBalloon", version.ref = "testballoon" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ jvm = "25"
 kotlinx-coroutines = "1.11.0"
 testballoon = "1.0.1-K2.4.0"
 kotest = "6.0.3"
-junit-platform-launcher = "1.14.4"
+junit-platform-launcher = "6.0.3"
 mockwebserver = "4.12.0"
 
 [libraries]


### PR DESCRIPTION
Migrates all 31 test files (domain, application, adapters) from JUnit5 +
kotlin.test + MockK + springmockk to [testBalloon](https://github.com/infix-de/testBalloon)
suites, using [testballoon-spring](https://github.com/yonatankarp/testballoon-spring)
`0.1.1` for the Spring tests and Kotest assertions throughout.

## What changed

- **Test framework:** every `class XTest { @Test }` becomes a top-level
  `val XSuite by testSuite { test("...") }`.
- **Spring tests:** `@WebFluxTest`/`@SpringBootTest` slices now use a carrier
  `class FooContext : SpringTestConfig()` + `springTest<FooContext>`, with
  value-based `mockBean<T>()` replacing springmockk `@MockkBean` and
  `bean<WebTestClient>()` replacing constructor injection.
- **Assertions:** `kotlin.test` → Kotest (`shouldBe`, `shouldThrow`, …).
- **Coroutines:** `runTest` dropped where no virtual time is used (testBalloon
  test bodies are suspend); kept only in `PicturePregenerationTest`.
- **Build:** testBalloon Gradle plugin on all three modules, Kotest +
  testballoon-spring deps, `org.junit.platform` forced to `6.0.3` (Spring Boot
  4.1 ships JUnit Jupiter 6 which needs platform 6.x; testBalloon also runs on
  6.0.3), `extra["kotlin.version"]` set on adapters before the Spring BOM.
  `kotlin-test` and `springmockk` removed at the end.

## Invariants held

- **Zero production (`src/main`) changes** — behavior-preserving test migration.
- **Coverage gates unchanged and green:** domain 100% line/branch, application
  and adapters 80%/70%.
- `./gradlew clean check` green from clean: 89 tests (domain 29, application 9,
  adapters 51).

## Notes

- Built on `main`. The `feat/pre-seed-pool` branch (16 more JUnit tests) is not
  covered here and will need the same treatment after it merges; expect build-file
  conflicts to resolve then. Its mutable pool fixtures must be constructed
  per-test, not at suite scope.
- `mockwebserver` is currently unused on `main` but kept because
  `feat/pre-seed-pool`'s `LocalStableDiffusionMachineTest` needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Migrated test suite to a new testing framework with improved test organization and assertion syntax.

## Chores
* Updated build configuration to support new testing infrastructure.
* Added GitHub Packages repository for test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->