### PR TITLE
test: migrate the suite to testBalloon + testballoon-spring + Kotest (with given/whenever/then DSL)

### DIFF
--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.openapi.contracts)
+    alias(libs.plugins.testballoon)
 }
+
+extra["kotlin.version"] = libs.versions.kotlin.get()
 
 kotlin {
     jvmToolchain {
@@ -33,6 +36,18 @@ dependencies {
     }
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.bootJar {

--- a/beat-the-machine-adapters/build.gradle.kts
+++ b/beat-the-machine-adapters/build.gradle.kts
@@ -31,9 +31,7 @@ dependencies {
     implementation(libs.bundles.spring.ai.starters)
 
     testImplementation(libs.bundles.unit.test)
-    testImplementation(libs.bundles.spring.boot.test) {
-        exclude("org.mockito", "mockito-core")
-    }
+    testImplementation(libs.bundles.spring.boot.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/ApplicationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/ApplicationTest.kt
@@ -1,11 +1,15 @@
 package com.yonatankarp.beatthemachine
 
-import org.junit.jupiter.api.Test
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class ApplicationTest {
-    @Test
-    fun `context loads`() {
+class ApplicationContext : SpringTestConfig()
+
+val ApplicationSuite by testSuite {
+    springTest<ApplicationContext> {
+        test("context loads") {}
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/HealthEndpointTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/HealthEndpointTest.kt
@@ -1,26 +1,28 @@
 package com.yonatankarp.beatthemachine
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class HealthEndpointTest(
-    @Autowired val client: WebTestClient,
-) {
-    @Test
-    fun `health endpoint reports UP`() {
-        client
-            .get()
-            .uri("/health")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("UP")
+class HealthEndpointContext : SpringTestConfig()
+
+val HealthEndpointSuite by testSuite {
+    springTest<HealthEndpointContext> {
+        test("health endpoint reports UP") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/health")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("UP")
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
@@ -3,6 +3,9 @@ package com.yonatankarp.beatthemachine.config
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.output.ai.SeedMachine
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -13,15 +16,21 @@ import org.springframework.context.annotation.Bean
 private val runner = ApplicationContextRunner().withUserConfiguration(MachineConfig::class.java)
 
 val MachineConfigSuite by testSuite {
-    test("defaults to the seed machine") {
-        runner.run { ctx -> ctx.getBean(Machine::class.java).shouldBeInstanceOf<SeedMachine>() }
-    }
+    given("the machine config") {
+        whenever("no image provider is configured") {
+            then("it defaults to the seed machine") {
+                runner.run { ctx -> ctx.getBean(Machine::class.java).shouldBeInstanceOf<SeedMachine>() }
+            }
+        }
 
-    test("selects local-sd when configured") {
-        runner
-            .withUserConfiguration(StubStorePictureConfig::class.java)
-            .withPropertyValues("btm.image.provider=local-sd", "btm.image.local-sd.base-url=http://localhost:7860")
-            .run { ctx -> ctx.getBean(Machine::class.java)::class.simpleName shouldBe "LocalStableDiffusionMachine" }
+        whenever("the local-sd provider is configured") {
+            then("it selects the local stable-diffusion machine") {
+                runner
+                    .withUserConfiguration(StubStorePictureConfig::class.java)
+                    .withPropertyValues("btm.image.provider=local-sd", "btm.image.local-sd.base-url=http://localhost:7860")
+                    .run { ctx -> ctx.getBean(Machine::class.java)::class.simpleName shouldBe "LocalStableDiffusionMachine" }
+            }
+        }
     }
 }
 

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/MachineConfigTest.kt
@@ -3,34 +3,33 @@ package com.yonatankarp.beatthemachine.config
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.output.ai.SeedMachine
-import org.junit.jupiter.api.Test
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
-import kotlin.test.assertTrue
 
-class MachineConfigTest {
-    private val runner = ApplicationContextRunner().withUserConfiguration(MachineConfig::class.java)
+private val runner = ApplicationContextRunner().withUserConfiguration(MachineConfig::class.java)
 
-    @Test
-    fun `defaults to the seed machine`() {
-        runner.run { ctx -> assertTrue(ctx.getBean(Machine::class.java) is SeedMachine) }
+val MachineConfigSuite by testSuite {
+    test("defaults to the seed machine") {
+        runner.run { ctx -> ctx.getBean(Machine::class.java).shouldBeInstanceOf<SeedMachine>() }
     }
 
-    @Test
-    fun `selects local-sd when configured`() {
+    test("selects local-sd when configured") {
         runner
             .withUserConfiguration(StubStorePictureConfig::class.java)
             .withPropertyValues("btm.image.provider=local-sd", "btm.image.local-sd.base-url=http://localhost:7860")
-            .run { ctx -> assertTrue(ctx.getBean(Machine::class.java)::class.simpleName == "LocalStableDiffusionMachine") }
+            .run { ctx -> ctx.getBean(Machine::class.java)::class.simpleName shouldBe "LocalStableDiffusionMachine" }
     }
+}
 
-    @Configuration
-    class StubStorePictureConfig {
-        @Bean
-        fun storePicture(): StorePicture =
-            object : StorePicture {
-                override suspend fun handle(command: StorePicture.Command): String = "/stub-url"
-            }
-    }
+@TestConfiguration
+class StubStorePictureConfig {
+    @Bean
+    fun storePicture(): StorePicture =
+        object : StorePicture {
+            override suspend fun handle(command: StorePicture.Command): String = "/stub-url"
+        }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
@@ -1,34 +1,22 @@
 package com.yonatankarp.beatthemachine.config
 
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
-import org.junit.jupiter.api.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
-class PictureScopeTest {
-    @Test
-    fun `is active before shutdown`() {
-        // Given
+val PictureScopeSuite by testSuite {
+    test("is active before shutdown") {
         val scope = PictureScope()
-
-        // When
-        val active = scope.isActive
-
-        // Then
-        assertTrue(active)
+        scope.isActive.shouldBeTrue()
     }
 
-    @Test
-    fun `destroy cancels the scope so no work outlives the application`() {
-        // Given
+    test("destroy cancels the scope so no work outlives the application") {
         val scope = PictureScope()
-
-        // When
         scope.destroy()
-
-        // Then
-        assertFalse(scope.isActive)
-        assertTrue(scope.coroutineContext.job.isCancelled)
+        scope.isActive.shouldBeFalse()
+        scope.coroutineContext.job.isCancelled
+            .shouldBeTrue()
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PictureScopeTest.kt
@@ -1,5 +1,8 @@
 package com.yonatankarp.beatthemachine.config
 
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -7,16 +10,22 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.job
 
 val PictureScopeSuite by testSuite {
-    test("is active before shutdown") {
-        val scope = PictureScope()
-        scope.isActive.shouldBeTrue()
-    }
+    given("a picture scope") {
+        whenever("the application is still running") {
+            then("it is active before shutdown") {
+                val scope = PictureScope()
+                scope.isActive.shouldBeTrue()
+            }
+        }
 
-    test("destroy cancels the scope so no work outlives the application") {
-        val scope = PictureScope()
-        scope.destroy()
-        scope.isActive.shouldBeFalse()
-        scope.coroutineContext.job.isCancelled
-            .shouldBeTrue()
+        whenever("destroy is called") {
+            then("it cancels the scope so no work outlives the application") {
+                val scope = PictureScope()
+                scope.destroy()
+                scope.isActive.shouldBeFalse()
+                scope.coroutineContext.job.isCancelled
+                    .shouldBeTrue()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
@@ -2,6 +2,9 @@ package com.yonatankarp.beatthemachine.config
 
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.output.ai.SeedPromptSource
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -9,7 +12,11 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 private val runner = ApplicationContextRunner().withUserConfiguration(PromptSourceConfig::class.java)
 
 val PromptSourceConfigSuite by testSuite {
-    test("defaults to the seed prompt source") {
-        runner.run { ctx -> ctx.getBean(PromptSource::class.java).shouldBeInstanceOf<SeedPromptSource>() }
+    given("the prompt source config") {
+        whenever("no prompt source is configured") {
+            then("it defaults to the seed prompt source") {
+                runner.run { ctx -> ctx.getBean(PromptSource::class.java).shouldBeInstanceOf<SeedPromptSource>() }
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/config/PromptSourceConfigTest.kt
@@ -2,15 +2,14 @@ package com.yonatankarp.beatthemachine.config
 
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.output.ai.SeedPromptSource
-import org.junit.jupiter.api.Test
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
-import kotlin.test.assertTrue
 
-class PromptSourceConfigTest {
-    private val runner = ApplicationContextRunner().withUserConfiguration(PromptSourceConfig::class.java)
+private val runner = ApplicationContextRunner().withUserConfiguration(PromptSourceConfig::class.java)
 
-    @Test
-    fun `defaults to the seed prompt source`() {
-        runner.run { ctx -> assertTrue(ctx.getBean(PromptSource::class.java) is SeedPromptSource) }
+val PromptSourceConfigSuite by testSuite {
+    test("defaults to the seed prompt source") {
+        runner.run { ctx -> ctx.getBean(PromptSource::class.java).shouldBeInstanceOf<SeedPromptSource>() }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -4,6 +4,9 @@ import com.yonatankarp.beatthemachine.openapi.v1.models.ChallengeStatus
 import com.yonatankarp.beatthemachine.openapi.v1.models.Difficulty
 import com.yonatankarp.beatthemachine.openapi.v1.models.MaskedToken
 import com.yonatankarp.beatthemachine.openapi.v1.models.PictureStatus
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.beatenChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.easyChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
@@ -16,68 +19,82 @@ import java.net.URI
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty as DomainDifficulty
 
 val ChallengeApiMapperSuite by testSuite {
-    test("maps a pending picture") {
-        val subject = mediumChallenge()
-        val response = subject.toApiResponse()
-        response.picture.status shouldBe PictureStatus.PENDING
-        response.picture.url shouldBe null
+    given("a challenge domain object") {
+        whenever("mapped to the API model") {
+            then("it maps a pending picture") {
+                val subject = mediumChallenge()
+                val response = subject.toApiResponse()
+                response.picture.status shouldBe PictureStatus.PENDING
+                response.picture.url shouldBe null
+            }
+
+            then("it maps a ready picture with its url") {
+                val subject = mediumChallenge().withPicture(readyPicture("http://img/1.png"))
+                val response = subject.toApiResponse()
+                response.picture.status shouldBe PictureStatus.READY
+                response.picture.url shouldBe URI.create("http://img/1.png")
+            }
+
+            then("it maps a failed picture") {
+                val subject = mediumChallenge().withPicture(failedPicture())
+                val response = subject.toApiResponse()
+                response.picture.status shouldBe PictureStatus.FAILED
+                response.picture.url shouldBe null
+            }
+
+            then("it degrades a ready picture with a malformed url to FAILED") {
+                val subject = mediumChallenge().withPicture(readyPicture("http:// bad url with spaces"))
+                val response = subject.toApiResponse()
+                response.picture.status shouldBe PictureStatus.FAILED
+                response.picture.url shouldBe null
+            }
+
+            then("it maps livesRemaining and the prompt-derived maxLives") {
+                val mediumChallenge = mediumChallenge()
+                val easyChallenge = easyChallenge()
+                val medium = mediumChallenge.toApiResponse()
+                val easy = easyChallenge.toApiResponse()
+                medium.livesRemaining shouldBe 6
+                medium.maxLives shouldBe mediumChallenge.maxLives().remaining
+                easy.maxLives shouldBe easyChallenge.maxLives().remaining
+            }
+        }
+
+        whenever("the challenge is in progress") {
+            then("it hides every word") {
+                val subject = mediumChallenge()
+                val response = subject.toApiResponse()
+                response.maskedPrompt shouldBe listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5))
+                response.status shouldBe ChallengeStatus.IN_PROGRESS
+            }
+        }
+
+        whenever("the challenge is lost") {
+            then("it reveals the whole prompt") {
+                val subject = lostChallenge()
+                val response = subject.toApiResponse()
+                response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+                response.status.value shouldBe "LOST"
+            }
+        }
+
+        whenever("the challenge is beaten") {
+            then("it reveals the whole prompt") {
+                val subject = beatenChallenge()
+                val response = subject.toApiResponse()
+                response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+                response.status.value shouldBe "BEATEN"
+            }
+        }
     }
 
-    test("maps a ready picture with its url") {
-        val subject = mediumChallenge().withPicture(readyPicture("http://img/1.png"))
-        val response = subject.toApiResponse()
-        response.picture.status shouldBe PictureStatus.READY
-        response.picture.url shouldBe URI.create("http://img/1.png")
-    }
-
-    test("maps a failed picture") {
-        val subject = mediumChallenge().withPicture(failedPicture())
-        val response = subject.toApiResponse()
-        response.picture.status shouldBe PictureStatus.FAILED
-        response.picture.url shouldBe null
-    }
-
-    test("degrades a ready picture with a malformed url to FAILED") {
-        val subject = mediumChallenge().withPicture(readyPicture("http:// bad url with spaces"))
-        val response = subject.toApiResponse()
-        response.picture.status shouldBe PictureStatus.FAILED
-        response.picture.url shouldBe null
-    }
-
-    test("hides every word while the challenge is in progress") {
-        val subject = mediumChallenge()
-        val response = subject.toApiResponse()
-        response.maskedPrompt shouldBe listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5))
-        response.status shouldBe ChallengeStatus.IN_PROGRESS
-    }
-
-    test("reveals the whole prompt once the challenge is lost") {
-        val subject = lostChallenge()
-        val response = subject.toApiResponse()
-        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
-        response.status.value shouldBe "LOST"
-    }
-
-    test("reveals the whole prompt once the challenge is beaten") {
-        val subject = beatenChallenge()
-        val response = subject.toApiResponse()
-        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
-        response.status.value shouldBe "BEATEN"
-    }
-
-    test("maps livesRemaining and the prompt-derived maxLives") {
-        val mediumChallenge = mediumChallenge()
-        val easyChallenge = easyChallenge()
-        val medium = mediumChallenge.toApiResponse()
-        val easy = easyChallenge.toApiResponse()
-        medium.livesRemaining shouldBe 6
-        medium.maxLives shouldBe mediumChallenge.maxLives().remaining
-        easy.maxLives shouldBe easyChallenge.maxLives().remaining
-    }
-
-    test("Difficulty toDomain maps each value to the same-named domain Difficulty") {
-        Difficulty.EASY.toDomain() shouldBe DomainDifficulty.EASY
-        Difficulty.MEDIUM.toDomain() shouldBe DomainDifficulty.MEDIUM
-        Difficulty.HARD.toDomain() shouldBe DomainDifficulty.HARD
+    given("an API Difficulty value") {
+        whenever("mapped to the domain model") {
+            then("it maps each value to the same-named domain Difficulty") {
+                Difficulty.EASY.toDomain() shouldBe DomainDifficulty.EASY
+                Difficulty.MEDIUM.toDomain() shouldBe DomainDifficulty.MEDIUM
+                Difficulty.HARD.toDomain() shouldBe DomainDifficulty.HARD
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ChallengeApiMapperTest.kt
@@ -10,129 +10,74 @@ import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import org.junit.jupiter.api.Test
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import java.net.URI
-import kotlin.test.assertEquals
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty as DomainDifficulty
 
-class ChallengeApiMapperTest {
-    @Test
-    fun `maps a pending picture`() {
-        // Given
+val ChallengeApiMapperSuite by testSuite {
+    test("maps a pending picture") {
         val subject = mediumChallenge()
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(PictureStatus.PENDING, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.PENDING
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `maps a ready picture with its url`() {
-        // Given
+    test("maps a ready picture with its url") {
         val subject = mediumChallenge().withPicture(readyPicture("http://img/1.png"))
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(PictureStatus.READY, response.picture.status)
-        assertEquals(URI.create("http://img/1.png"), response.picture.url)
+        response.picture.status shouldBe PictureStatus.READY
+        response.picture.url shouldBe URI.create("http://img/1.png")
     }
 
-    @Test
-    fun `maps a failed picture`() {
-        // Given
+    test("maps a failed picture") {
         val subject = mediumChallenge().withPicture(failedPicture())
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(PictureStatus.FAILED, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.FAILED
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `degrades a ready picture with a malformed url to FAILED`() {
-        // Given
+    test("degrades a ready picture with a malformed url to FAILED") {
         val subject = mediumChallenge().withPicture(readyPicture("http:// bad url with spaces"))
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(PictureStatus.FAILED, response.picture.status)
-        assertEquals(null, response.picture.url)
+        response.picture.status shouldBe PictureStatus.FAILED
+        response.picture.url shouldBe null
     }
 
-    @Test
-    fun `hides every word while the challenge is in progress`() {
-        // Given
+    test("hides every word while the challenge is in progress") {
         val subject = mediumChallenge()
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5)), response.maskedPrompt)
-        assertEquals(ChallengeStatus.IN_PROGRESS, response.status)
+        response.maskedPrompt shouldBe listOf(MaskedToken(false, null, 5), MaskedToken(false, null, 5))
+        response.status shouldBe ChallengeStatus.IN_PROGRESS
     }
 
-    @Test
-    fun `reveals the whole prompt once the challenge is lost`() {
-        // Given
+    test("reveals the whole prompt once the challenge is lost") {
         val subject = lostChallenge()
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
-        assertEquals("LOST", response.status.value)
+        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+        response.status.value shouldBe "LOST"
     }
 
-    @Test
-    fun `reveals the whole prompt once the challenge is beaten`() {
-        // Given
+    test("reveals the whole prompt once the challenge is beaten") {
         val subject = beatenChallenge()
-
-        // When
         val response = subject.toApiResponse()
-
-        // Then
-        assertEquals(listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5)), response.maskedPrompt)
-        assertEquals("BEATEN", response.status.value)
+        response.maskedPrompt shouldBe listOf(MaskedToken(true, "hello", 5), MaskedToken(true, "world", 5))
+        response.status.value shouldBe "BEATEN"
     }
 
-    @Test
-    fun `maps livesRemaining and the prompt-derived maxLives`() {
-        // Given
+    test("maps livesRemaining and the prompt-derived maxLives") {
         val mediumChallenge = mediumChallenge()
         val easyChallenge = easyChallenge()
-
-        // When
         val medium = mediumChallenge.toApiResponse()
         val easy = easyChallenge.toApiResponse()
-
-        // Then
-        assertEquals(6, medium.livesRemaining)
-        assertEquals(mediumChallenge.maxLives().remaining, medium.maxLives)
-        assertEquals(easyChallenge.maxLives().remaining, easy.maxLives)
+        medium.livesRemaining shouldBe 6
+        medium.maxLives shouldBe mediumChallenge.maxLives().remaining
+        easy.maxLives shouldBe easyChallenge.maxLives().remaining
     }
 
-    @Test
-    fun `Difficulty toDomain maps each value to the same-named domain Difficulty`() {
-        // When
-        val easy = Difficulty.EASY.toDomain()
-        val medium = Difficulty.MEDIUM.toDomain()
-        val hard = Difficulty.HARD.toDomain()
-
-        // Then
-        assertEquals(DomainDifficulty.EASY, easy)
-        assertEquals(DomainDifficulty.MEDIUM, medium)
-        assertEquals(DomainDifficulty.HARD, hard)
+    test("Difficulty toDomain maps each value to the same-named domain Difficulty") {
+        Difficulty.EASY.toDomain() shouldBe DomainDifficulty.EASY
+        Difficulty.MEDIUM.toDomain() shouldBe DomainDifficulty.MEDIUM
+        Difficulty.HARD.toDomain() shouldBe DomainDifficulty.HARD
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/ForfeitChallengeControllerTest.kt
@@ -1,49 +1,48 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.lostChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(ForfeitChallengeController::class)
-@MockkBean(types = [ForfeitChallenge::class])
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class ForfeitChallengeControllerTest(
-    private val client: WebTestClient,
-    private val forfeitChallenge: ForfeitChallenge,
-) {
-    @Test
-    fun `forfeit reveals the prompt and reports LOST`() {
-        coEvery { forfeitChallenge handle any() } returns lostChallenge()
+class ForfeitChallengeWebContext : SpringTestConfig()
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/forfeit")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("LOST")
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(true)
-    }
+val ForfeitChallengeControllerSuite by testSuite {
+    springTest<ForfeitChallengeWebContext> {
+        val forfeitChallenge = mockBean<ForfeitChallenge>()
 
-    @Test
-    fun `forfeit with concurrent modification returns 409`() {
-        coEvery { forfeitChallenge handle any() } throws OptimisticLockConflict(aChallengeId())
+        test("forfeit reveals the prompt and reports LOST") {
+            coEvery { forfeitChallenge handle any() } returns lostChallenge()
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/forfeit")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(409)
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/forfeit")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("LOST")
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(true)
+        }
+
+        test("forfeit with concurrent modification returns 409") {
+            coEvery { forfeitChallenge handle any() } throws OptimisticLockConflict(aChallengeId())
+
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/forfeit")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(409)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/GetChallengeControllerTest.kt
@@ -1,60 +1,58 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(GetChallengeController::class)
-@MockkBean(types = [GetChallenge::class])
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class GetChallengeControllerTest(
-    private val client: WebTestClient,
-    private val getChallenge: GetChallenge,
-) {
-    @Test
-    fun `GET returns the challenge state`() {
-        val challenge = mediumChallenge()
-        coEvery { getChallenge answer any() } returns challenge
+class GetChallengeWebContext : SpringTestConfig()
 
-        client
-            .get()
-            .uri("/api/challenges/${challenge.id.value}")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.status")
-            .isEqualTo("IN_PROGRESS")
-            .jsonPath("$.livesRemaining")
-            .isEqualTo(6)
-    }
+val GetChallengeControllerSuite by testSuite {
+    springTest<GetChallengeWebContext> {
+        val getChallenge = mockBean<GetChallenge>()
 
-    @Test
-    fun `GET an unknown challenge returns 404`() {
-        coEvery { getChallenge answer any() } throws ChallengeNotFound(aChallengeId())
+        test("GET returns the challenge state") {
+            val challenge = mediumChallenge()
+            coEvery { getChallenge answer any() } returns challenge
 
-        client
-            .get()
-            .uri("/api/challenges/${aChallengeId().value}")
-            .exchange()
-            .expectStatus()
-            .isNotFound
-    }
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/${challenge.id.value}")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo("IN_PROGRESS")
+                .jsonPath("$.livesRemaining")
+                .isEqualTo(6)
+        }
 
-    @Test
-    fun `a malformed challenge id returns 422`() {
-        client
-            .get()
-            .uri("/api/challenges/not-a-uuid")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+        test("GET an unknown challenge returns 404") {
+            coEvery { getChallenge answer any() } throws ChallengeNotFound(aChallengeId())
+
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/${aChallengeId().value}")
+                .exchange()
+                .expectStatus()
+                .isNotFound
+        }
+
+        test("a malformed challenge id returns 422") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/api/challenges/not-a-uuid")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/MakeGuessControllerTest.kt
@@ -1,6 +1,5 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.MakeGuess
 import com.yonatankarp.beatthemachine.domain.exception.ChallengeAlreadyOver
@@ -9,91 +8,88 @@ import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(MakeGuessController::class)
-@MockkBean(types = [MakeGuess::class])
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class MakeGuessControllerTest(
-    private val client: WebTestClient,
-    private val makeGuess: MakeGuess,
-) {
-    @Test
-    fun `a successful guess returns the updated masked prompt`() {
-        val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
-        coEvery { makeGuess handle any() } returns (afterHit to GuessOutcome.HIT)
+class MakeGuessWebContext : SpringTestConfig()
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(true)
-            .jsonPath("$.maskedPrompt[0].word")
-            .isEqualTo("hello")
-    }
+val MakeGuessControllerSuite by testSuite {
+    springTest<MakeGuessWebContext> {
+        val makeGuess = mockBean<MakeGuess>()
 
-    @Test
-    fun `guessing an unknown challenge returns 404`() {
-        coEvery { makeGuess handle any() } throws ChallengeNotFound(aChallengeId())
+        test("a successful guess returns the updated masked prompt") {
+            val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
+            coEvery { makeGuess handle any() } returns (afterHit to GuessOutcome.HIT)
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isNotFound
-    }
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(true)
+                .jsonPath("$.maskedPrompt[0].word")
+                .isEqualTo("hello")
+        }
 
-    @Test
-    fun `guessing on an already-over challenge returns 409`() {
-        coEvery { makeGuess handle any() } throws ChallengeAlreadyOver(aChallengeId())
+        test("guessing an unknown challenge returns 404") {
+            coEvery { makeGuess handle any() } throws ChallengeNotFound(aChallengeId())
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"hello"}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(409)
-    }
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isNotFound
+        }
 
-    @Test
-    fun `a domain-rejected guess returns 422`() {
-        coEvery { makeGuess handle any() } throws InvalidGuess("not a single word")
+        test("guessing on an already-over challenge returns 409") {
+            coEvery { makeGuess handle any() } throws ChallengeAlreadyOver(aChallengeId())
 
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"two words"}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
-    }
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"hello"}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(409)
+        }
 
-    @Test
-    fun `guessing with a blank word returns 422`() {
-        client
-            .post()
-            .uri("/api/challenges/${aChallengeId().value}/guesses")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("""{"word":"   "}""")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+        test("a domain-rejected guess returns 422") {
+            coEvery { makeGuess handle any() } throws InvalidGuess("not a single word")
+
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"two words"}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
+
+        test("guessing with a blank word returns 422") {
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges/${aChallengeId().value}/guesses")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("""{"word":"   "}""")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
@@ -5,11 +5,11 @@ import com.yonatankarp.beatthemachine.application.port.output.StoredImage
 import com.yonatankarp.testballoon.spring.SpringTestConfig
 import com.yonatankarp.testballoon.spring.springTest
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
-import kotlin.test.assertContentEquals
 
 @WebFluxTest(PictureController::class)
 class PictureWebContext : SpringTestConfig()
@@ -35,7 +35,7 @@ val PictureControllerSuite by testSuite {
                 .expectHeader()
                 .valueEquals("Cache-Control", "public, max-age=31536000, immutable")
                 .expectBody<ByteArray>()
-                .consumeWith { assertContentEquals(byteArrayOf(1, 2, 3), it.responseBody) }
+                .consumeWith { it.responseBody shouldBe byteArrayOf(1, 2, 3) }
         }
 
         test("returns 404 for unknown id") {

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/PictureControllerTest.kt
@@ -1,83 +1,71 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StoredImage
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import kotlin.test.assertContentEquals
 
 @WebFluxTest(PictureController::class)
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class PictureControllerTest(
-    private val client: WebTestClient,
-) {
-    @MockkBean
-    lateinit var findPicture: FindPicture
+class PictureWebContext : SpringTestConfig()
 
-    @Test
-    fun `serves image bytes with correct content-type`() {
-        // Given
-        coEvery { findPicture answer FindPicture.Query("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "image/png")
+val PictureControllerSuite by testSuite {
+    springTest<PictureWebContext> {
+        val findPicture = mockBean<FindPicture>()
 
-        // When
-        val response =
-            client
-                .get()
-                .uri("/images/abc")
-                .exchange()
+        test("serves image bytes with correct content-type") {
+            coEvery { findPicture answer FindPicture.Query("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "image/png")
 
-        // Then
-        response
-            .expectStatus()
-            .isOk
-            .expectHeader()
-            .contentType("image/png")
-            .expectHeader()
-            .valueEquals("Cache-Control", "public, max-age=31536000, immutable")
-            .expectBody<ByteArray>()
-            .consumeWith { assertContentEquals(byteArrayOf(1, 2, 3), it.responseBody) }
-    }
+            val response =
+                bean<WebTestClient>()
+                    .get()
+                    .uri("/images/abc")
+                    .exchange()
 
-    @Test
-    fun `returns 404 for unknown id`() {
-        // Given
-        coEvery { findPicture answer FindPicture.Query("unknown") } returns null
+            response
+                .expectStatus()
+                .isOk
+                .expectHeader()
+                .contentType("image/png")
+                .expectHeader()
+                .valueEquals("Cache-Control", "public, max-age=31536000, immutable")
+                .expectBody<ByteArray>()
+                .consumeWith { assertContentEquals(byteArrayOf(1, 2, 3), it.responseBody) }
+        }
 
-        // When
-        val response =
-            client
-                .get()
-                .uri("/images/unknown")
-                .exchange()
+        test("returns 404 for unknown id") {
+            coEvery { findPicture answer FindPicture.Query("unknown") } returns null
 
-        // Then
-        response
-            .expectStatus()
-            .isNotFound
-    }
+            val response =
+                bean<WebTestClient>()
+                    .get()
+                    .uri("/images/unknown")
+                    .exchange()
 
-    @Test
-    fun `coerces non-image content-type to application octet-stream`() {
-        // Given
-        coEvery { findPicture answer FindPicture.Query("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "text/plain")
+            response
+                .expectStatus()
+                .isNotFound
+        }
 
-        // When
-        val response =
-            client
-                .get()
-                .uri("/images/abc")
-                .exchange()
+        test("coerces non-image content-type to application octet-stream") {
+            coEvery { findPicture answer FindPicture.Query("abc") } returns StoredImage(byteArrayOf(1, 2, 3), "text/plain")
 
-        // Then
-        response
-            .expectStatus()
-            .isOk
-            .expectHeader()
-            .contentType("application/octet-stream")
+            val response =
+                bean<WebTestClient>()
+                    .get()
+                    .uri("/images/abc")
+                    .exchange()
+
+            response
+                .expectStatus()
+                .isOk
+                .expectHeader()
+                .contentType("application/octet-stream")
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SecurityHeadersFilterTest.kt
@@ -1,34 +1,36 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.string.shouldContain
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
-import kotlin.test.assertContains
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class SecurityHeadersFilterTest(
-    @Autowired private val client: WebTestClient,
-) {
-    @Test
-    fun `every response carries the security headers`() {
-        client
-            .get()
-            .uri("/")
-            .exchange()
-            .expectHeader()
-            .valueEquals("X-Content-Type-Options", "nosniff")
-            .expectHeader()
-            .valueEquals("Referrer-Policy", "no-referrer")
-            .expectHeader()
-            .value("Content-Security-Policy") { csp ->
-                assertContains(csp, "default-src 'self'")
-                assertContains(csp, "script-src 'self'")
-                assertContains(csp, "frame-ancestors 'none'")
-                assertContains(csp, "object-src 'none'")
-                assertContains(csp, "img-src 'self' https:")
-            }
+class SecurityHeadersFilterContext : SpringTestConfig()
+
+val SecurityHeadersFilterSuite by testSuite {
+    springTest<SecurityHeadersFilterContext> {
+        test("every response carries the security headers") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/")
+                .exchange()
+                .expectHeader()
+                .valueEquals("X-Content-Type-Options", "nosniff")
+                .expectHeader()
+                .valueEquals("Referrer-Policy", "no-referrer")
+                .expectHeader()
+                .value("Content-Security-Policy") { csp ->
+                    csp.shouldContain("default-src 'self'")
+                    csp.shouldContain("script-src 'self'")
+                    csp.shouldContain("frame-ancestors 'none'")
+                    csp.shouldContain("object-src 'none'")
+                    csp.shouldContain("img-src 'self' https:")
+                }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/SpaForwardingRouterTest.kt
@@ -1,20 +1,17 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient
 
-class SpaForwardingRouterTest {
-    private val client =
+val SpaForwardingRouterSuite by testSuite {
+    test("the router is scoped to app and does not match other paths") {
         WebTestClient
             .bindToRouterFunction(SpaForwardingRouter().spaRoutes())
             .build()
-
-    @Test
-    fun `the router is scoped to app and does not match other paths`() {
-        client
             .get()
             .uri("/api/challenges/anything")
             .exchange()
@@ -25,28 +22,28 @@ class SpaForwardingRouterTest {
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-class SpaForwardingRouterIntegrationTest(
-    @Autowired private val client: WebTestClient,
-) {
-    @Test
-    fun `root redirects to the SPA entry`() {
-        client
-            .get()
-            .uri("/")
-            .exchange()
-            .expectStatus()
-            .isFound
-            .expectHeader()
-            .valueEquals("Location", "/app/")
-    }
+class SpaForwardingRouterIntegrationContext : SpringTestConfig()
 
-    @Test
-    fun `app deep links are served by the SPA entry point`() {
-        client
-            .get()
-            .uri("/app/some/deep/link")
-            .exchange()
-            .expectStatus()
-            .isOk
+val SpaForwardingRouterIntegrationSuite by testSuite {
+    springTest<SpaForwardingRouterIntegrationContext> {
+        test("root redirects to the SPA entry") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/")
+                .exchange()
+                .expectStatus()
+                .isFound
+                .expectHeader()
+                .valueEquals("Location", "/app/")
+        }
+
+        test("app deep links are served by the SPA entry point") {
+            bean<WebTestClient>()
+                .get()
+                .uri("/app/some/deep/link")
+                .exchange()
+                .expectStatus()
+                .isOk
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/input/web/StartChallengeControllerTest.kt
@@ -1,53 +1,52 @@
 package com.yonatankarp.beatthemachine.input.web
 
-import com.ninjasquad.springmockk.MockkBean
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.spring.SpringTestConfig
+import com.yonatankarp.testballoon.spring.springTest
+import de.infix.testBalloon.framework.core.testSuite
 import io.mockk.coEvery
-import org.junit.jupiter.api.Test
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
-import org.springframework.test.context.TestConstructor
 import org.springframework.test.web.reactive.server.WebTestClient
 
 @WebFluxTest(StartChallengeController::class)
-@MockkBean(types = [StartChallenge::class])
-@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class StartChallengeControllerTest(
-    private val client: WebTestClient,
-    private val startChallenge: StartChallenge,
-) {
-    @Test
-    fun `POST creates a challenge and never leaks the prompt`() {
-        coEvery { startChallenge handle any() } returns mediumChallenge()
+class StartChallengeWebContext : SpringTestConfig()
 
-        client
-            .post()
-            .uri("/api/challenges")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.livesRemaining")
-            .isEqualTo(6)
-            .jsonPath("$.status")
-            .isEqualTo("IN_PROGRESS")
-            .jsonPath("$.picture.status")
-            .isEqualTo("PENDING")
-            .jsonPath("$.maskedPrompt[0].revealed")
-            .isEqualTo(false)
-            .jsonPath("$.prompt")
-            .doesNotExist()
-            .jsonPath("$.secretPrompt")
-            .doesNotExist()
-    }
+val StartChallengeControllerSuite by testSuite {
+    springTest<StartChallengeWebContext> {
+        val startChallenge = mockBean<StartChallenge>()
 
-    @Test
-    fun `invalid difficulty query param returns 422`() {
-        client
-            .post()
-            .uri("/api/challenges?difficulty=NOPE")
-            .exchange()
-            .expectStatus()
-            .isEqualTo(422)
+        test("POST creates a challenge and never leaks the prompt") {
+            coEvery { startChallenge handle any() } returns mediumChallenge()
+
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges")
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody()
+                .jsonPath("$.livesRemaining")
+                .isEqualTo(6)
+                .jsonPath("$.status")
+                .isEqualTo("IN_PROGRESS")
+                .jsonPath("$.picture.status")
+                .isEqualTo("PENDING")
+                .jsonPath("$.maskedPrompt[0].revealed")
+                .isEqualTo(false)
+                .jsonPath("$.prompt")
+                .doesNotExist()
+                .jsonPath("$.secretPrompt")
+                .doesNotExist()
+        }
+
+        test("invalid difficulty query param returns 422") {
+            bean<WebTestClient>()
+                .post()
+                .uri("/api/challenges?difficulty=NOPE")
+                .exchange()
+                .expectStatus()
+                .isEqualTo(422)
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
@@ -4,22 +4,33 @@ import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.aroundAll
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
 import java.util.Base64
-import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
-class LocalStableDiffusionMachineTest {
-    private val storePicture = mockk<StorePicture>()
+private val server = MockWebServer()
 
-    private fun machine(): LocalStableDiffusionMachine =
+val LocalStableDiffusionMachineSuite by testSuite(
+    testConfig =
+        TestConfig.aroundAll { elementAction ->
+            server.start()
+            try {
+                elementAction()
+            } finally {
+                server.shutdown()
+            }
+        },
+) {
+    val storePicture = mockk<StorePicture>()
+
+    fun machine(): LocalStableDiffusionMachine =
         LocalStableDiffusionMachine(
             server.url("/").toString(),
             storePicture,
@@ -29,61 +40,28 @@ class LocalStableDiffusionMachineTest {
             timeout = 5.seconds,
         )
 
-    @Test
-    fun `stores the decoded image and returns Ready`() =
-        runTest {
-            // Given
-            val pngBytes = byteArrayOf(1, 2, 3)
-            val b64 = Base64.getEncoder().encodeToString(pngBytes)
-            server.enqueue(
-                MockResponse()
-                    .setHeader("Content-Type", "application/json")
-                    .setBody("""{"images":["$b64"]}"""),
-            )
-            coEvery { storePicture handle StorePicture.Command(pngBytes, "image/png") } returns "xyz"
+    test("stores the decoded image and returns Ready") {
+        val pngBytes = byteArrayOf(1, 2, 3)
+        val b64 = Base64.getEncoder().encodeToString(pngBytes)
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"images":["$b64"]}"""),
+        )
+        coEvery { storePicture handle StorePicture.Command(pngBytes, "image/png") } returns "xyz"
+        val result = machine() answer Machine.Query(Prompt("dragon eating a cookie"))
+        result shouldBe Picture.Ready("/images/xyz")
+    }
 
-            // When
-            val result = machine() answer Machine.Query(Prompt("dragon eating a cookie"))
+    test("server error yields Failed") {
+        server.enqueue(MockResponse().setResponseCode(500))
+        machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+    }
 
-            // Then
-            assertEquals(Picture.Ready("/images/xyz"), result)
-        }
-
-    @Test
-    fun `server error yields Failed`() =
-        runTest {
-            // Given
-            server.enqueue(MockResponse().setResponseCode(500))
-
-            // When / Then
-            assertEquals(Picture.Failed, machine() answer Machine.Query(Prompt("anything")))
-        }
-
-    @Test
-    fun `empty image list yields Failed`() =
-        runTest {
-            // Given
-            server.enqueue(
-                MockResponse().setHeader("Content-Type", "application/json").setBody("""{"images":[]}"""),
-            )
-
-            // When / Then
-            assertEquals(Picture.Failed, machine() answer Machine.Query(Prompt("anything")))
-        }
-
-    companion object {
-        private val server = MockWebServer()
-
-        @JvmStatic
-        @BeforeAll
-        fun startServer() {
-            server.start()
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun stopServer() {
-            server.shutdown()
-        }
+    test("empty image list yields Failed") {
+        server.enqueue(
+            MockResponse().setHeader("Content-Type", "application/json").setBody("""{"images":[]}"""),
+        )
+        machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/LocalStableDiffusionMachineTest.kt
@@ -4,6 +4,9 @@ import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.TestConfig
 import de.infix.testBalloon.framework.core.aroundAll
 import de.infix.testBalloon.framework.core.testSuite
@@ -40,28 +43,36 @@ val LocalStableDiffusionMachineSuite by testSuite(
             timeout = 5.seconds,
         )
 
-    test("stores the decoded image and returns Ready") {
-        val pngBytes = byteArrayOf(1, 2, 3)
-        val b64 = Base64.getEncoder().encodeToString(pngBytes)
-        server.enqueue(
-            MockResponse()
-                .setHeader("Content-Type", "application/json")
-                .setBody("""{"images":["$b64"]}"""),
-        )
-        coEvery { storePicture handle StorePicture.Command(pngBytes, "image/png") } returns "xyz"
-        val result = machine() answer Machine.Query(Prompt("dragon eating a cookie"))
-        result shouldBe Picture.Ready("/images/xyz")
-    }
+    given("a local Stable Diffusion machine") {
+        whenever("the upstream returns a generated image") {
+            then("it stores the decoded image and returns Ready") {
+                val pngBytes = byteArrayOf(1, 2, 3)
+                val b64 = Base64.getEncoder().encodeToString(pngBytes)
+                server.enqueue(
+                    MockResponse()
+                        .setHeader("Content-Type", "application/json")
+                        .setBody("""{"images":["$b64"]}"""),
+                )
+                coEvery { storePicture handle StorePicture.Command(pngBytes, "image/png") } returns "xyz"
+                val result = machine() answer Machine.Query(Prompt("dragon eating a cookie"))
+                result shouldBe Picture.Ready("/images/xyz")
+            }
+        }
 
-    test("server error yields Failed") {
-        server.enqueue(MockResponse().setResponseCode(500))
-        machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
-    }
+        whenever("the upstream returns a server error") {
+            then("it yields Failed") {
+                server.enqueue(MockResponse().setResponseCode(500))
+                machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+            }
+        }
 
-    test("empty image list yields Failed") {
-        server.enqueue(
-            MockResponse().setHeader("Content-Type", "application/json").setBody("""{"images":[]}"""),
-        )
-        machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+        whenever("the upstream returns an empty image list") {
+            then("it yields Failed") {
+                server.enqueue(
+                    MockResponse().setHeader("Content-Type", "application/json").setBody("""{"images":[]}"""),
+                )
+                machine() answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -12,6 +12,9 @@ import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryFindPe
 import com.yonatankarp.beatthemachine.output.persistence.inmemory.InMemoryStoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import de.infix.testBalloon.framework.core.testSuite
@@ -25,106 +28,123 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 val PicturePregenerationSuite by testSuite {
-    test("generation flips a pending picture to ready and persists it") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
-            val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
-            advanceUntilIdle()
-            (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Ready("http://img/1.png")
-        }
-    }
-
-    test("a failing machine persists a failed picture") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val machine = mockk<Machine>().also { coEvery { it answer any() } throws RuntimeException("boom") }
-            val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
-            advanceUntilIdle()
-            (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Failed
-        }
-    }
-
-    test("enqueue for an unknown challenge is a no-op") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
-            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(aChallengeId())
-            advanceUntilIdle()
-        }
-    }
-
-    test("retryPending re-enqueues every challenge still awaiting a picture") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/retry.png") }
-            val pending = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            val done =
-                storeChallenge handle
-                    StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/done.png")))
-            pregeneration(machine, storeChallenge, findById, findPending, this).retryPending()
-            advanceUntilIdle()
-            (findById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Ready("http://img/retry.png")
-            (findById answer FindChallengeById.Query(done.id))?.picture shouldBe Picture.Ready("http://img/done.png")
-        }
-    }
-
-    test("a concurrent version bump is retried so the picture still persists") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val seeded = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            var firstStore = true
-            val racingStore =
-                object : StoreChallenge {
-                    override suspend fun handle(command: StoreChallenge.Command): Challenge {
-                        val challenge = command.challenge
-                        if (firstStore && challenge.picture is Picture.Ready) {
-                            firstStore = false
-                            storeChallenge handle StoreChallenge.Command(findById answer FindChallengeById.Query(challenge.id) ?: challenge)
-                            throw OptimisticLockConflict(challenge.id)
-                        }
-                        return storeChallenge handle StoreChallenge.Command(challenge)
-                    }
+    given("a picture pregeneration pipeline") {
+        whenever("enqueueing a pending challenge with a working machine") {
+            then("generation flips a pending picture to ready and persists it") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
+                    val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                    pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
+                    advanceUntilIdle()
+                    (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Ready("http://img/1.png")
                 }
-            val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/raced.png") }
-            pregeneration(machine, racingStore, findById, findPending, this).enqueue(seeded.id)
-            advanceUntilIdle()
-            (findById answer FindChallengeById.Query(seeded.id))?.picture shouldBe Picture.Ready("http://img/raced.png")
+            }
         }
-    }
 
-    test("enqueue sheds work once the admission bound is full") {
-        runTest {
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findById = InMemoryFindChallengeById(store)
-            val findPending = InMemoryFindPendingChallenges(store)
-            val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/admitted.png") }
-            val admitted = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            val shed = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()))
-            val pregen = pregeneration(machine, storeChallenge, findById, findPending, this, maxQueued = 1)
-            pregen.enqueue(admitted.id)
-            pregen.enqueue(shed.id)
-            advanceUntilIdle()
-            (findById answer FindChallengeById.Query(admitted.id))?.picture shouldBe Picture.Ready("http://img/admitted.png")
-            (findById answer FindChallengeById.Query(shed.id))?.picture shouldBe Picture.Pending
+        whenever("the machine fails") {
+            then("it persists a failed picture") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } throws RuntimeException("boom") }
+                    val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                    pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
+                    advanceUntilIdle()
+                    (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Failed
+                }
+            }
+        }
+
+        whenever("enqueueing an unknown challenge") {
+            then("it is a no-op") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
+                    pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(aChallengeId())
+                    advanceUntilIdle()
+                }
+            }
+        }
+
+        whenever("retrying pending challenges") {
+            then("it re-enqueues every challenge still awaiting a picture") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/retry.png") }
+                    val pending = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                    val done =
+                        storeChallenge handle
+                            StoreChallenge.Command(
+                                mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/done.png")),
+                            )
+                    pregeneration(machine, storeChallenge, findById, findPending, this).retryPending()
+                    advanceUntilIdle()
+                    (findById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Ready("http://img/retry.png")
+                    (findById answer FindChallengeById.Query(done.id))?.picture shouldBe Picture.Ready("http://img/done.png")
+                }
+            }
+        }
+
+        whenever("a concurrent version bump conflicts during persistence") {
+            then("it is retried so the picture still persists") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val seeded = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                    var firstStore = true
+                    val racingStore =
+                        object : StoreChallenge {
+                            override suspend fun handle(command: StoreChallenge.Command): Challenge {
+                                val challenge = command.challenge
+                                if (firstStore && challenge.picture is Picture.Ready) {
+                                    firstStore = false
+                                    storeChallenge handle
+                                        StoreChallenge.Command(findById answer FindChallengeById.Query(challenge.id) ?: challenge)
+                                    throw OptimisticLockConflict(challenge.id)
+                                }
+                                return storeChallenge handle StoreChallenge.Command(challenge)
+                            }
+                        }
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/raced.png") }
+                    pregeneration(machine, racingStore, findById, findPending, this).enqueue(seeded.id)
+                    advanceUntilIdle()
+                    (findById answer FindChallengeById.Query(seeded.id))?.picture shouldBe Picture.Ready("http://img/raced.png")
+                }
+            }
+        }
+
+        whenever("the admission bound is full") {
+            then("enqueue sheds work") {
+                runTest {
+                    val store = InMemoryChallengeStore()
+                    val storeChallenge = InMemoryStoreChallenge(store)
+                    val findById = InMemoryFindChallengeById(store)
+                    val findPending = InMemoryFindPendingChallenges(store)
+                    val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/admitted.png") }
+                    val admitted = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                    val shed = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()))
+                    val pregen = pregeneration(machine, storeChallenge, findById, findPending, this, maxQueued = 1)
+                    pregen.enqueue(admitted.id)
+                    pregen.enqueue(shed.id)
+                    advanceUntilIdle()
+                    (findById answer FindChallengeById.Query(admitted.id))?.picture shouldBe Picture.Ready("http://img/admitted.png")
+                    (findById answer FindChallengeById.Query(shed.id))?.picture shouldBe Picture.Pending
+                }
+            }
         }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/PicturePregenerationTest.kt
@@ -14,88 +14,82 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class PicturePregenerationTest {
-    private val store = InMemoryChallengeStore()
-    private val storeChallenge = InMemoryStoreChallenge(store)
-    private val findById = InMemoryFindChallengeById(store)
-    private val findPending = InMemoryFindPendingChallenges(store)
-
-    @Test
-    fun `generation flips a pending picture to ready and persists it`() =
+val PicturePregenerationSuite by testSuite {
+    test("generation flips a pending picture to ready and persists it") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
             val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-
-            // When
-            pregeneration(machine, this).enqueue(c.id)
+            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
             advanceUntilIdle()
-
-            // Then
-            assertEquals(Picture.Ready("http://img/1.png"), (findById answer FindChallengeById.Query(c.id))?.picture)
+            (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Ready("http://img/1.png")
         }
+    }
 
-    @Test
-    fun `a failing machine persists a failed picture`() =
+    test("a failing machine persists a failed picture") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = mockk<Machine>().also { coEvery { it answer any() } throws RuntimeException("boom") }
             val c = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-
-            // When
-            pregeneration(machine, this).enqueue(c.id)
+            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(c.id)
             advanceUntilIdle()
-
-            // Then
-            assertEquals(Picture.Failed, (findById answer FindChallengeById.Query(c.id))?.picture)
+            (findById answer FindChallengeById.Query(c.id))?.picture shouldBe Picture.Failed
         }
+    }
 
-    @Test
-    fun `enqueue for an unknown challenge is a no-op`() =
+    test("enqueue for an unknown challenge is a no-op") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/1.png") }
-
-            // When
-            pregeneration(machine, this).enqueue(aChallengeId())
+            pregeneration(machine, storeChallenge, findById, findPending, this).enqueue(aChallengeId())
             advanceUntilIdle()
         }
+    }
 
-    @Test
-    fun `retryPending re-enqueues every challenge still awaiting a picture`() =
+    test("retryPending re-enqueues every challenge still awaiting a picture") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/retry.png") }
             val pending = storeChallenge handle StoreChallenge.Command(mediumChallenge())
             val done =
                 storeChallenge handle
                     StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/done.png")))
-
-            // When
-            pregeneration(machine, this).retryPending()
+            pregeneration(machine, storeChallenge, findById, findPending, this).retryPending()
             advanceUntilIdle()
-
-            // Then
-            assertEquals(Picture.Ready("http://img/retry.png"), (findById answer FindChallengeById.Query(pending.id))?.picture)
-            assertEquals(Picture.Ready("http://img/done.png"), (findById answer FindChallengeById.Query(done.id))?.picture)
+            (findById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Ready("http://img/retry.png")
+            (findById answer FindChallengeById.Query(done.id))?.picture shouldBe Picture.Ready("http://img/done.png")
         }
+    }
 
-    @Test
-    fun `a concurrent version bump is retried so the picture still persists`() =
+    test("a concurrent version bump is retried so the picture still persists") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val seeded = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-
             var firstStore = true
             val racingStore =
                 object : StoreChallenge {
@@ -110,38 +104,36 @@ class PicturePregenerationTest {
                     }
                 }
             val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/raced.png") }
-
-            // When
-            pregeneration(machine, this, racingStore).enqueue(seeded.id)
+            pregeneration(machine, racingStore, findById, findPending, this).enqueue(seeded.id)
             advanceUntilIdle()
-
-            // Then
-            assertEquals(Picture.Ready("http://img/raced.png"), (findById answer FindChallengeById.Query(seeded.id))?.picture)
+            (findById answer FindChallengeById.Query(seeded.id))?.picture shouldBe Picture.Ready("http://img/raced.png")
         }
+    }
 
-    @Test
-    fun `enqueue sheds work once the admission bound is full`() =
+    test("enqueue sheds work once the admission bound is full") {
         runTest {
-            // Given
+            val store = InMemoryChallengeStore()
+            val storeChallenge = InMemoryStoreChallenge(store)
+            val findById = InMemoryFindChallengeById(store)
+            val findPending = InMemoryFindPendingChallenges(store)
             val machine = mockk<Machine>().also { coEvery { it answer any() } returns Picture.Ready("http://img/admitted.png") }
             val admitted = storeChallenge handle StoreChallenge.Command(mediumChallenge())
             val shed = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()))
-            val pregeneration = pregeneration(machine, this, maxQueued = 1)
-
-            // When
-            pregeneration.enqueue(admitted.id)
-            pregeneration.enqueue(shed.id)
+            val pregen = pregeneration(machine, storeChallenge, findById, findPending, this, maxQueued = 1)
+            pregen.enqueue(admitted.id)
+            pregen.enqueue(shed.id)
             advanceUntilIdle()
-
-            // Then
-            assertEquals(Picture.Ready("http://img/admitted.png"), (findById answer FindChallengeById.Query(admitted.id))?.picture)
-            assertEquals(Picture.Pending, (findById answer FindChallengeById.Query(shed.id))?.picture)
+            (findById answer FindChallengeById.Query(admitted.id))?.picture shouldBe Picture.Ready("http://img/admitted.png")
+            (findById answer FindChallengeById.Query(shed.id))?.picture shouldBe Picture.Pending
         }
-
-    private fun pregeneration(
-        machine: Machine,
-        scope: CoroutineScope,
-        store: StoreChallenge = storeChallenge,
-        maxQueued: Int = 50,
-    ) = PicturePregeneration(machine, findById, store, findPending, scope, maxQueued)
+    }
 }
+
+private fun pregeneration(
+    machine: Machine,
+    store: StoreChallenge,
+    findById: InMemoryFindChallengeById,
+    findPending: InMemoryFindPendingChallenges,
+    scope: CoroutineScope,
+    maxQueued: Int = 50,
+) = PicturePregeneration(machine, findById, store, findPending, scope, maxQueued)

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
@@ -3,36 +3,21 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class SeedMachineTest {
-    private val machine = SeedMachine()
+val SeedMachineSuite by testSuite {
+    val machine = SeedMachine()
 
-    @Test
-    fun `returns the curated url for a known prompt`() =
-        runTest {
-            // Given
-            val (prompt, url) = SEED.first()
+    test("returns the curated url for a known prompt") {
+        val (prompt, url) = SEED.first()
+        val result = machine answer Machine.Query(prompt)
+        result shouldBe Picture.Ready(url)
+    }
 
-            // When
-            val result = machine answer Machine.Query(prompt)
-
-            // Then
-            assertEquals(Picture.Ready(url), result)
-        }
-
-    @Test
-    fun `returns Failed for an unknown prompt`() =
-        runTest {
-            // Given
-            val prompt = "a prompt that is not seeded".asPrompt()
-
-            // When
-            val result = machine answer Machine.Query(prompt)
-
-            // Then
-            assertEquals(Picture.Failed, result)
-        }
+    test("returns Failed for an unknown prompt") {
+        val prompt = "a prompt that is not seeded".asPrompt()
+        val result = machine answer Machine.Query(prompt)
+        result shouldBe Picture.Failed
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedMachineTest.kt
@@ -3,21 +3,30 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 
 val SeedMachineSuite by testSuite {
     val machine = SeedMachine()
 
-    test("returns the curated url for a known prompt") {
-        val (prompt, url) = SEED.first()
-        val result = machine answer Machine.Query(prompt)
-        result shouldBe Picture.Ready(url)
-    }
+    given("a seed machine") {
+        whenever("answering a known seeded prompt") {
+            then("it returns the curated url") {
+                val (prompt, url) = SEED.first()
+                val result = machine answer Machine.Query(prompt)
+                result shouldBe Picture.Ready(url)
+            }
+        }
 
-    test("returns Failed for an unknown prompt") {
-        val prompt = "a prompt that is not seeded".asPrompt()
-        val result = machine answer Machine.Query(prompt)
-        result shouldBe Picture.Failed
+        whenever("answering an unknown prompt") {
+            then("it returns Failed") {
+                val prompt = "a prompt that is not seeded".asPrompt()
+                val result = machine answer Machine.Query(prompt)
+                result shouldBe Picture.Failed
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
@@ -2,15 +2,22 @@ package com.yonatankarp.beatthemachine.output.ai
 
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 
 val SeedPromptSourceSuite by testSuite {
-    test("returns a prompt from the curated seed set") {
-        val seedPrompts = SEED.map { it.first }.toSet()
-        repeat(20) {
-            val prompt = SeedPromptSource() answer PromptSource.Query(Difficulty.MEDIUM)
-            (prompt in seedPrompts).shouldBeTrue()
+    given("a seed prompt source") {
+        whenever("answering a prompt query") {
+            then("it returns a prompt from the curated seed set") {
+                val seedPrompts = SEED.map { it.first }.toSet()
+                repeat(20) {
+                    val prompt = SeedPromptSource() answer PromptSource.Query(Difficulty.MEDIUM)
+                    (prompt in seedPrompts).shouldBeTrue()
+                }
+            }
         }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SeedPromptSourceTest.kt
@@ -2,21 +2,15 @@ package com.yonatankarp.beatthemachine.output.ai
 
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
 
-class SeedPromptSourceTest {
-    @Test
-    fun `returns a prompt from the curated seed set`() =
-        runTest {
-            // Given
-            val seedPrompts = SEED.map { it.first }.toSet()
-
-            // When / Then
-            repeat(20) {
-                val prompt = SeedPromptSource() answer PromptSource.Query(Difficulty.MEDIUM)
-                assertTrue(prompt in seedPrompts, "returned prompt must come from the curated SEED set")
-            }
+val SeedPromptSourceSuite by testSuite {
+    test("returns a prompt from the curated seed set") {
+        val seedPrompts = SEED.map { it.first }.toSet()
+        repeat(20) {
+            val prompt = SeedPromptSource() answer PromptSource.Query(Difficulty.MEDIUM)
+            (prompt in seedPrompts).shouldBeTrue()
         }
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
@@ -4,6 +4,9 @@ import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
@@ -20,40 +23,48 @@ import org.springframework.ai.image.ImageResponse
 import java.util.Base64
 
 val SpringAiImageMachineSuite by testSuite {
-    test("decodes b64 image, stores it, and returns Ready") {
-        val storePicture = mockk<StorePicture>()
-        val imageModel = mockk<ImageModel>()
-        val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
-        every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
-        coEvery { storePicture handle any<StorePicture.Command>() } returns "paid1"
-        val machine = SpringAiImageMachine(imageModel, storePicture)
-        val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
-        result shouldBe Picture.Ready("/images/paid1")
-    }
+    given("a Spring AI image machine") {
+        whenever("the model returns a base64 image") {
+            then("it decodes the image, stores it, and returns Ready") {
+                val storePicture = mockk<StorePicture>()
+                val imageModel = mockk<ImageModel>()
+                val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
+                every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
+                coEvery { storePicture handle any<StorePicture.Command>() } returns "paid1"
+                val machine = SpringAiImageMachine(imageModel, storePicture)
+                val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
+                result shouldBe Picture.Ready("/images/paid1")
+            }
+        }
 
-    test("fetches image bytes when the model returns a url") {
-        val storePicture = mockk<StorePicture>()
-        val imageModel = mockk<ImageModel>()
-        val server = MockWebServer()
-        server.start()
-        val pngBytes = "PNGDATA".toByteArray()
-        server.enqueue(MockResponse().setBody("PNGDATA"))
-        every { imageModel.call(any()) } returns
-            ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
-        val saved = slot<StorePicture.Command>()
-        coEvery { storePicture handle capture(saved) } returns "paid2"
-        val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient())
-        val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
-        result shouldBe Picture.Ready("/images/paid2")
-        pngBytes.contentEquals(saved.captured.bytes).shouldBeTrue()
-        server.shutdown()
-    }
+        whenever("the model returns a url") {
+            then("it fetches the image bytes and returns Ready") {
+                val storePicture = mockk<StorePicture>()
+                val imageModel = mockk<ImageModel>()
+                val server = MockWebServer()
+                server.start()
+                val pngBytes = "PNGDATA".toByteArray()
+                server.enqueue(MockResponse().setBody("PNGDATA"))
+                every { imageModel.call(any()) } returns
+                    ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
+                val saved = slot<StorePicture.Command>()
+                coEvery { storePicture handle capture(saved) } returns "paid2"
+                val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient())
+                val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
+                result shouldBe Picture.Ready("/images/paid2")
+                pngBytes.contentEquals(saved.captured.bytes).shouldBeTrue()
+                server.shutdown()
+            }
+        }
 
-    test("model failure yields Failed") {
-        val storePicture = mockk<StorePicture>()
-        val imageModel = mockk<ImageModel>()
-        every { imageModel.call(any()) } throws RuntimeException("boom")
-        val machine = SpringAiImageMachine(imageModel, storePicture)
-        machine answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+        whenever("the model fails") {
+            then("it yields Failed") {
+                val storePicture = mockk<StorePicture>()
+                val imageModel = mockk<ImageModel>()
+                every { imageModel.call(any()) } throws RuntimeException("boom")
+                val machine = SpringAiImageMachine(imageModel, storePicture)
+                machine answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
@@ -4,75 +4,56 @@ import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.jupiter.api.Test
 import org.springframework.ai.image.Image
 import org.springframework.ai.image.ImageGeneration
 import org.springframework.ai.image.ImageModel
 import org.springframework.ai.image.ImageResponse
 import java.util.Base64
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-class SpringAiImageMachineTest {
-    private val storePicture = mockk<StorePicture>()
-    private val imageModel = mockk<ImageModel>()
+val SpringAiImageMachineSuite by testSuite {
+    test("decodes b64 image, stores it, and returns Ready") {
+        val storePicture = mockk<StorePicture>()
+        val imageModel = mockk<ImageModel>()
+        val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
+        every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
+        coEvery { storePicture handle any<StorePicture.Command>() } returns "paid1"
+        val machine = SpringAiImageMachine(imageModel, storePicture)
+        val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
+        result shouldBe Picture.Ready("/images/paid1")
+    }
 
-    @Test
-    fun `decodes b64 image, stores it, and returns Ready`() =
-        runTest {
-            // Given
-            val b64 = Base64.getEncoder().encodeToString(byteArrayOf(5, 6, 7))
-            every { imageModel.call(any()) } returns ImageResponse(listOf(ImageGeneration(Image(null, b64))))
-            coEvery { storePicture handle any<StorePicture.Command>() } returns "paid1"
+    test("fetches image bytes when the model returns a url") {
+        val storePicture = mockk<StorePicture>()
+        val imageModel = mockk<ImageModel>()
+        val server = MockWebServer()
+        server.start()
+        val pngBytes = "PNGDATA".toByteArray()
+        server.enqueue(MockResponse().setBody("PNGDATA"))
+        every { imageModel.call(any()) } returns
+            ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
+        val saved = slot<StorePicture.Command>()
+        coEvery { storePicture handle capture(saved) } returns "paid2"
+        val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient())
+        val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
+        result shouldBe Picture.Ready("/images/paid2")
+        pngBytes.contentEquals(saved.captured.bytes).shouldBeTrue()
+        server.shutdown()
+    }
 
-            // When
-            val machine = SpringAiImageMachine(imageModel, storePicture)
-            val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
-
-            // Then
-            assertEquals(Picture.Ready("/images/paid1"), result)
-        }
-
-    @Test
-    fun `fetches image bytes when the model returns a url`() =
-        runTest {
-            // Given
-            val server = MockWebServer()
-            server.start()
-            val pngBytes = "PNGDATA".toByteArray()
-            server.enqueue(MockResponse().setBody("PNGDATA"))
-            every { imageModel.call(any()) } returns
-                ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
-            val saved = slot<StorePicture.Command>()
-            coEvery { storePicture handle capture(saved) } returns "paid2"
-
-            // When
-            val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient())
-            val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
-
-            // Then
-            assertEquals(Picture.Ready("/images/paid2"), result)
-            assertTrue(pngBytes.contentEquals(saved.captured.bytes))
-            server.shutdown()
-        }
-
-    @Test
-    fun `model failure yields Failed`() =
-        runTest {
-            // Given
-            every { imageModel.call(any()) } throws RuntimeException("boom")
-
-            // When
-            val machine = SpringAiImageMachine(imageModel, storePicture)
-
-            // Then
-            assertEquals(Picture.Failed, machine answer Machine.Query(Prompt("anything")))
-        }
+    test("model failure yields Failed") {
+        val storePicture = mockk<StorePicture>()
+        val imageModel = mockk<ImageModel>()
+        every { imageModel.call(any()) } throws RuntimeException("boom")
+        val machine = SpringAiImageMachine(imageModel, storePicture)
+        machine answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
@@ -3,44 +3,57 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 
 val SpringAiPromptSourceSuite by testSuite {
-    test("returns a valid phrase trimmed to the difficulty band") {
-        val fallback = mockk<PromptSource>()
-        val llm = LlmText { _, _ -> "  dragon eating a cookie  " }
-        val source = SpringAiPromptSource(llm, fallback)
-        val result = source answer PromptSource.Query(Difficulty.HARD)
-        result shouldBe Prompt("dragon eating a cookie")
-    }
+    given("a prompt source backed by Spring AI") {
+        whenever("the model returns a phrase within the difficulty band") {
+            then("it returns the phrase trimmed to the band") {
+                val fallback = mockk<PromptSource>()
+                val llm = LlmText { _, _ -> "  dragon eating a cookie  " }
+                val source = SpringAiPromptSource(llm, fallback)
+                val result = source answer PromptSource.Query(Difficulty.HARD)
+                result shouldBe Prompt("dragon eating a cookie")
+            }
+        }
 
-    test("retries past empty output then returns first in-band phrase") {
-        val fallback = mockk<PromptSource>()
-        var calls = 0
-        val llm = LlmText { _, _ -> if (calls++ == 0) "" else "ocean wave" }
-        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 3)
-        val result = source answer PromptSource.Query(Difficulty.EASY)
-        result shouldBe Prompt("ocean wave")
-    }
+        whenever("the model returns empty output before an in-band phrase") {
+            then("it retries past the empty output then returns the first in-band phrase") {
+                val fallback = mockk<PromptSource>()
+                var calls = 0
+                val llm = LlmText { _, _ -> if (calls++ == 0) "" else "ocean wave" }
+                val source = SpringAiPromptSource(llm, fallback, maxAttempts = 3)
+                val result = source answer PromptSource.Query(Difficulty.EASY)
+                result shouldBe Prompt("ocean wave")
+            }
+        }
 
-    test("falls back to seed source when the model keeps throwing") {
-        val fallback = mockk<PromptSource>()
-        val llm = LlmText { _, _ -> throw RuntimeException("model down") }
-        coEvery { fallback answer PromptSource.Query(Difficulty.MEDIUM) } returns Prompt("dolphin on fire")
-        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
-        val result = source answer PromptSource.Query(Difficulty.MEDIUM)
-        result shouldBe Prompt("dolphin on fire")
-    }
+        whenever("the model keeps throwing") {
+            then("it falls back to the seed source") {
+                val fallback = mockk<PromptSource>()
+                val llm = LlmText { _, _ -> throw RuntimeException("model down") }
+                coEvery { fallback answer PromptSource.Query(Difficulty.MEDIUM) } returns Prompt("dolphin on fire")
+                val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+                val result = source answer PromptSource.Query(Difficulty.MEDIUM)
+                result shouldBe Prompt("dolphin on fire")
+            }
+        }
 
-    test("falls back when output never fits the difficulty band") {
-        val fallback = mockk<PromptSource>()
-        val llm = LlmText { _, _ -> "this phrase is far too many words to be easy" }
-        coEvery { fallback answer PromptSource.Query(Difficulty.EASY) } returns Prompt("red car")
-        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
-        val result = source answer PromptSource.Query(Difficulty.EASY)
-        result shouldBe Prompt("red car")
+        whenever("the model output never fits the difficulty band") {
+            then("it falls back to the seed source") {
+                val fallback = mockk<PromptSource>()
+                val llm = LlmText { _, _ -> "this phrase is far too many words to be easy" }
+                coEvery { fallback answer PromptSource.Query(Difficulty.EASY) } returns Prompt("red car")
+                val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+                val result = source answer PromptSource.Query(Difficulty.EASY)
+                result shouldBe Prompt("red car")
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiPromptSourceTest.kt
@@ -3,71 +3,44 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
-class SpringAiPromptSourceTest {
-    private val fallback = mockk<PromptSource>()
+val SpringAiPromptSourceSuite by testSuite {
+    test("returns a valid phrase trimmed to the difficulty band") {
+        val fallback = mockk<PromptSource>()
+        val llm = LlmText { _, _ -> "  dragon eating a cookie  " }
+        val source = SpringAiPromptSource(llm, fallback)
+        val result = source answer PromptSource.Query(Difficulty.HARD)
+        result shouldBe Prompt("dragon eating a cookie")
+    }
 
-    @Test
-    fun `returns a valid phrase trimmed to the difficulty band`() =
-        runTest {
-            // Given
-            val llm = LlmText { _, _ -> "  dragon eating a cookie  " }
-            val source = SpringAiPromptSource(llm, fallback)
+    test("retries past empty output then returns first in-band phrase") {
+        val fallback = mockk<PromptSource>()
+        var calls = 0
+        val llm = LlmText { _, _ -> if (calls++ == 0) "" else "ocean wave" }
+        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 3)
+        val result = source answer PromptSource.Query(Difficulty.EASY)
+        result shouldBe Prompt("ocean wave")
+    }
 
-            // When
-            val result = source answer PromptSource.Query(Difficulty.HARD)
+    test("falls back to seed source when the model keeps throwing") {
+        val fallback = mockk<PromptSource>()
+        val llm = LlmText { _, _ -> throw RuntimeException("model down") }
+        coEvery { fallback answer PromptSource.Query(Difficulty.MEDIUM) } returns Prompt("dolphin on fire")
+        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+        val result = source answer PromptSource.Query(Difficulty.MEDIUM)
+        result shouldBe Prompt("dolphin on fire")
+    }
 
-            // Then
-            assertEquals(Prompt("dragon eating a cookie"), result)
-        }
-
-    @Test
-    fun `retries past empty output then returns first in-band phrase`() =
-        runTest {
-            // Given
-            var calls = 0
-            val llm = LlmText { _, _ -> if (calls++ == 0) "" else "ocean wave" }
-            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 3)
-
-            // When
-            val result = source answer PromptSource.Query(Difficulty.EASY)
-
-            // Then
-            assertEquals(Prompt("ocean wave"), result)
-        }
-
-    @Test
-    fun `falls back to seed source when the model keeps throwing`() =
-        runTest {
-            // Given
-            val llm = LlmText { _, _ -> throw RuntimeException("model down") }
-            coEvery { fallback answer PromptSource.Query(Difficulty.MEDIUM) } returns Prompt("dolphin on fire")
-            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
-
-            // When
-            val result = source answer PromptSource.Query(Difficulty.MEDIUM)
-
-            // Then
-            assertEquals(Prompt("dolphin on fire"), result)
-        }
-
-    @Test
-    fun `falls back when output never fits the difficulty band`() =
-        runTest {
-            // Given
-            val llm = LlmText { _, _ -> "this phrase is far too many words to be easy" }
-            coEvery { fallback answer PromptSource.Query(Difficulty.EASY) } returns Prompt("red car")
-            val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
-
-            // When
-            val result = source answer PromptSource.Query(Difficulty.EASY)
-
-            // Then
-            assertEquals(Prompt("red car"), result)
-        }
+    test("falls back when output never fits the difficulty band") {
+        val fallback = mockk<PromptSource>()
+        val llm = LlmText { _, _ -> "this phrase is far too many words to be easy" }
+        coEvery { fallback answer PromptSource.Query(Difficulty.EASY) } returns Prompt("red car")
+        val source = SpringAiPromptSource(llm, fallback, maxAttempts = 2)
+        val result = source answer PromptSource.Query(Difficulty.EASY)
+        result shouldBe Prompt("red car")
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -3,26 +3,37 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
 val InMemoryFindChallengeByIdSuite by testSuite {
-    test("finds a stored challenge") {
-        val store = InMemoryChallengeStore()
-        val storeChallenge = InMemoryStoreChallenge(store)
-        val findChallengeById = InMemoryFindChallengeById(store)
-        val saved = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-        val found = findChallengeById answer FindChallengeById.Query(saved.id)
-        found?.id shouldBe saved.id
+    given("a stored challenge") {
+        whenever("finding it by id") {
+            then("it returns the stored challenge") {
+                val store = InMemoryChallengeStore()
+                val storeChallenge = InMemoryStoreChallenge(store)
+                val findChallengeById = InMemoryFindChallengeById(store)
+                val saved = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                val found = findChallengeById answer FindChallengeById.Query(saved.id)
+                found?.id shouldBe saved.id
+            }
+        }
     }
 
-    test("returns null for an unknown id") {
-        val store = InMemoryChallengeStore()
-        val findChallengeById = InMemoryFindChallengeById(store)
-        val unknownId = aChallengeId()
-        val found = findChallengeById answer FindChallengeById.Query(unknownId)
-        found.shouldBeNull()
+    given("an unknown id") {
+        whenever("finding the challenge") {
+            then("it returns null") {
+                val store = InMemoryChallengeStore()
+                val findChallengeById = InMemoryFindChallengeById(store)
+                val unknownId = aChallengeId()
+                val found = findChallengeById answer FindChallengeById.Query(unknownId)
+                found.shouldBeNull()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindChallengeByIdTest.kt
@@ -4,40 +4,25 @@ import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 
-class InMemoryFindChallengeByIdTest {
-    @Test
-    fun `finds a stored challenge`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findChallengeById = InMemoryFindChallengeById(store)
-            val saved = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+val InMemoryFindChallengeByIdSuite by testSuite {
+    test("finds a stored challenge") {
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val findChallengeById = InMemoryFindChallengeById(store)
+        val saved = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+        val found = findChallengeById answer FindChallengeById.Query(saved.id)
+        found?.id shouldBe saved.id
+    }
 
-            // When
-            val found = findChallengeById answer FindChallengeById.Query(saved.id)
-
-            // Then
-            assertEquals(saved.id, found?.id)
-        }
-
-    @Test
-    fun `returns null for an unknown id`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val findChallengeById = InMemoryFindChallengeById(store)
-            val unknownId = aChallengeId()
-
-            // When
-            val found = findChallengeById answer FindChallengeById.Query(unknownId)
-
-            // Then
-            assertNull(found)
-        }
+    test("returns null for an unknown id") {
+        val store = InMemoryChallengeStore()
+        val findChallengeById = InMemoryFindChallengeById(store)
+        val unknownId = aChallengeId()
+        val found = findChallengeById answer FindChallengeById.Query(unknownId)
+        found.shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -5,27 +5,19 @@ import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class InMemoryFindPendingChallengesTest {
-    @Test
-    fun `returns only challenges whose picture is pending`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val findPendingChallenges = InMemoryFindPendingChallenges(store)
-            val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-            val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
-            storeChallenge handle
-                StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
-
-            // When
-            val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
-
-            // Then
-            assertEquals(setOf(pendingA.id, pendingB.id), ids)
-        }
+val InMemoryFindPendingChallengesSuite by testSuite {
+    test("returns only challenges whose picture is pending") {
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val findPendingChallenges = InMemoryFindPendingChallenges(store)
+        val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+        val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
+        storeChallenge handle
+            StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
+        val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
+        ids shouldBe setOf(pendingA.id, pendingB.id)
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPendingChallengesTest.kt
@@ -3,21 +3,28 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 
 val InMemoryFindPendingChallengesSuite by testSuite {
-    test("returns only challenges whose picture is pending") {
-        val store = InMemoryChallengeStore()
-        val storeChallenge = InMemoryStoreChallenge(store)
-        val findPendingChallenges = InMemoryFindPendingChallenges(store)
-        val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge())
-        val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
-        storeChallenge handle
-            StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
-        val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
-        ids shouldBe setOf(pendingA.id, pendingB.id)
+    given("challenges with pending and ready pictures") {
+        whenever("finding pending challenges") {
+            then("it returns only the ones whose picture is pending") {
+                val store = InMemoryChallengeStore()
+                val storeChallenge = InMemoryStoreChallenge(store)
+                val findPendingChallenges = InMemoryFindPendingChallenges(store)
+                val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge())
+                val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
+                storeChallenge handle
+                    StoreChallenge.Command(mediumChallenge(prompt = "foo bar".asPrompt()).withPicture(readyPicture("http://img/1.png")))
+                val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
+                ids shouldBe setOf(pendingA.id, pendingB.id)
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPictureTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPictureTest.kt
@@ -2,26 +2,37 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
 val InMemoryFindPictureSuite by testSuite {
-    test("round-trips bytes and content type") {
-        val storage = InMemoryPictureStorage()
-        val storePicture = InMemoryStorePicture(storage)
-        val findPicture = InMemoryFindPicture(storage)
-        val bytes = byteArrayOf(9, 8, 7)
-        val id = storePicture handle StorePicture.Command(bytes, "image/png")
-        val loaded = (findPicture answer FindPicture.Query(id))!!
-        loaded.contentType shouldBe "image/png"
-        bytes.contentEquals(loaded.bytes).shouldBeTrue()
+    given("a stored picture") {
+        whenever("finding it by id") {
+            then("it round-trips bytes and content type") {
+                val storage = InMemoryPictureStorage()
+                val storePicture = InMemoryStorePicture(storage)
+                val findPicture = InMemoryFindPicture(storage)
+                val bytes = byteArrayOf(9, 8, 7)
+                val id = storePicture handle StorePicture.Command(bytes, "image/png")
+                val loaded = (findPicture answer FindPicture.Query(id))!!
+                loaded.contentType shouldBe "image/png"
+                bytes.contentEquals(loaded.bytes).shouldBeTrue()
+            }
+        }
     }
 
-    test("answer returns null for unknown id") {
-        val storage = InMemoryPictureStorage()
-        val findPicture = InMemoryFindPicture(storage)
-        (findPicture answer FindPicture.Query("nope")).shouldBeNull()
+    given("an unknown id") {
+        whenever("finding the picture") {
+            then("it returns null") {
+                val storage = InMemoryPictureStorage()
+                val findPicture = InMemoryFindPicture(storage)
+                (findPicture answer FindPicture.Query("nope")).shouldBeNull()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPictureTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryFindPictureTest.kt
@@ -2,36 +2,26 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 
-class InMemoryFindPictureTest {
-    private val storage = InMemoryPictureStorage()
-    private val storePicture = InMemoryStorePicture(storage)
-    private val findPicture = InMemoryFindPicture(storage)
+val InMemoryFindPictureSuite by testSuite {
+    test("round-trips bytes and content type") {
+        val storage = InMemoryPictureStorage()
+        val storePicture = InMemoryStorePicture(storage)
+        val findPicture = InMemoryFindPicture(storage)
+        val bytes = byteArrayOf(9, 8, 7)
+        val id = storePicture handle StorePicture.Command(bytes, "image/png")
+        val loaded = (findPicture answer FindPicture.Query(id))!!
+        loaded.contentType shouldBe "image/png"
+        bytes.contentEquals(loaded.bytes).shouldBeTrue()
+    }
 
-    @Test
-    fun `round-trips bytes and content type`() =
-        runTest {
-            // Given
-            val bytes = byteArrayOf(9, 8, 7)
-
-            // When
-            val id = storePicture handle StorePicture.Command(bytes, "image/png")
-            val loaded = (findPicture answer FindPicture.Query(id))!!
-
-            // Then
-            assertEquals("image/png", loaded.contentType)
-            assertTrue(bytes.contentEquals(loaded.bytes))
-        }
-
-    @Test
-    fun `answer returns null for unknown id`() =
-        runTest {
-            // When / Then
-            assertNull(findPicture answer FindPicture.Query("nope"))
-        }
+    test("answer returns null for unknown id") {
+        val storage = InMemoryPictureStorage()
+        val findPicture = InMemoryFindPicture(storage)
+        (findPicture answer FindPicture.Query("nope")).shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -2,25 +2,36 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 
 val InMemoryStoreChallengesSuite by testSuite {
-    test("stores and bumps the version") {
-        val store = InMemoryChallengeStore()
-        val storeChallenge = InMemoryStoreChallenge(store)
-        val challenge = mediumChallenge()
-        val saved = storeChallenge handle StoreChallenge.Command(challenge)
-        saved.version shouldBe 1L
+    given("a new challenge") {
+        whenever("storing it") {
+            then("it bumps the version") {
+                val store = InMemoryChallengeStore()
+                val storeChallenge = InMemoryStoreChallenge(store)
+                val challenge = mediumChallenge()
+                val saved = storeChallenge handle StoreChallenge.Command(challenge)
+                saved.version shouldBe 1L
+            }
+        }
     }
 
-    test("rejects a stale version") {
-        val store = InMemoryChallengeStore()
-        val storeChallenge = InMemoryStoreChallenge(store)
-        val c = mediumChallenge()
-        storeChallenge handle StoreChallenge.Command(c)
-        shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+    given("an already stored challenge") {
+        whenever("storing it again with a stale version") {
+            then("it throws OptimisticLockConflict") {
+                val store = InMemoryChallengeStore()
+                val storeChallenge = InMemoryStoreChallenge(store)
+                val c = mediumChallenge()
+                storeChallenge handle StoreChallenge.Command(c)
+                shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStoreChallengeTest.kt
@@ -3,37 +3,24 @@ package com.yonatankarp.beatthemachine.output.persistence.inmemory
 import com.yonatankarp.beatthemachine.application.exception.OptimisticLockConflict
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class InMemoryStoreChallengeTest {
-    @Test
-    fun `stores and bumps the version`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val challenge = mediumChallenge()
+val InMemoryStoreChallengesSuite by testSuite {
+    test("stores and bumps the version") {
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val challenge = mediumChallenge()
+        val saved = storeChallenge handle StoreChallenge.Command(challenge)
+        saved.version shouldBe 1L
+    }
 
-            // When
-            val saved = storeChallenge handle StoreChallenge.Command(challenge)
-
-            // Then
-            assertEquals(1L, saved.version)
-        }
-
-    @Test
-    fun `rejects a stale version`() =
-        runTest {
-            // Given
-            val store = InMemoryChallengeStore()
-            val storeChallenge = InMemoryStoreChallenge(store)
-            val c = mediumChallenge()
-            storeChallenge handle StoreChallenge.Command(c)
-
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
-        }
+    test("rejects a stale version") {
+        val store = InMemoryChallengeStore()
+        val storeChallenge = InMemoryStoreChallenge(store)
+        val c = mediumChallenge()
+        storeChallenge handle StoreChallenge.Command(c)
+        shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStorePictureTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStorePictureTest.kt
@@ -1,20 +1,27 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
 
 val InMemoryStorePictureSuite by testSuite {
-    test("handle returns an id and stores the bytes") {
-        val storage = InMemoryPictureStorage()
-        val storePicture = InMemoryStorePicture(storage)
-        val bytes = byteArrayOf(9, 8, 7)
-        val id = storePicture handle StorePicture.Command(bytes, "image/png")
-        id.shouldNotBeBlank()
-        val stored = storage.byId[id]!!
-        stored.contentType shouldBe "image/png"
-        bytes.contentEquals(stored.bytes).shouldBeTrue()
+    given("picture bytes and a content type") {
+        whenever("storing them") {
+            then("it returns an id and stores the bytes") {
+                val storage = InMemoryPictureStorage()
+                val storePicture = InMemoryStorePicture(storage)
+                val bytes = byteArrayOf(9, 8, 7)
+                val id = storePicture handle StorePicture.Command(bytes, "image/png")
+                id.shouldNotBeBlank()
+                val stored = storage.byId[id]!!
+                stored.contentType shouldBe "image/png"
+                bytes.contentEquals(stored.bytes).shouldBeTrue()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStorePictureTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/inmemory/InMemoryStorePictureTest.kt
@@ -1,28 +1,20 @@
 package com.yonatankarp.beatthemachine.output.persistence.inmemory
 
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
 
-class InMemoryStorePictureTest {
-    private val storage = InMemoryPictureStorage()
-    private val storePicture = InMemoryStorePicture(storage)
-
-    @Test
-    fun `handle returns an id and stores the bytes`() =
-        runTest {
-            // Given
-            val bytes = byteArrayOf(9, 8, 7)
-
-            // When
-            val id = storePicture handle StorePicture.Command(bytes, "image/png")
-
-            // Then
-            assertTrue(id.isNotBlank())
-            val stored = storage.byId[id]!!
-            assertEquals("image/png", stored.contentType)
-            assertTrue(bytes.contentEquals(stored.bytes))
-        }
+val InMemoryStorePictureSuite by testSuite {
+    test("handle returns an id and stores the bytes") {
+        val storage = InMemoryPictureStorage()
+        val storePicture = InMemoryStorePicture(storage)
+        val bytes = byteArrayOf(9, 8, 7)
+        val id = storePicture handle StorePicture.Command(bytes, "image/png")
+        id.shouldNotBeBlank()
+        val stored = storage.byId[id]!!
+        stored.contentType shouldBe "image/png"
+        bytes.contentEquals(stored.bytes).shouldBeTrue()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
@@ -4,7 +4,10 @@ import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
 import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.nulls.shouldBeNull
@@ -12,21 +15,29 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 val SqliteFindChallengeByIdITSuite by testSuite {
-    test("finds a stored challenge with its fields intact") {
-        val (storeChallenge, findChallengeById) = newSqliteAdapters()
-        val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
-        storeChallenge handle StoreChallenge.Command(c)
-        val found = findChallengeById answer FindChallengeById.Query(c.id)
-        found.shouldNotBeNull()
-        found.id shouldBe c.id
-        found.secretPrompt().text shouldBe "pixel art cat"
-        found.lives.remaining shouldBe 5
+    given("a stored challenge") {
+        whenever("finding it by id") {
+            then("it finds the stored challenge with its fields intact") {
+                val (storeChallenge, findChallengeById) = newSqliteAdapters()
+                val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
+                storeChallenge handle StoreChallenge.Command(c)
+                val found = findChallengeById answer FindChallengeById.Query(c.id)
+                found.shouldNotBeNull()
+                found.id shouldBe c.id
+                found.secretPrompt().text shouldBe "pixel art cat"
+                found.lives.remaining shouldBe 5
+            }
+        }
     }
 
-    test("returns null for an unknown id") {
-        val (_, findChallengeById) = newSqliteAdapters()
-        val unknownId = aChallengeId()
-        val found = findChallengeById answer FindChallengeById.Query(unknownId)
-        found.shouldBeNull()
+    given("an unknown id") {
+        whenever("finding the challenge by id") {
+            then("it returns null") {
+                val (_, findChallengeById) = newSqliteAdapters()
+                val unknownId = aChallengeId()
+                val found = findChallengeById answer FindChallengeById.Query(unknownId)
+                found.shouldBeNull()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindChallengeByIdIntegrationTest.kt
@@ -6,52 +6,27 @@ import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 
-class SqliteFindChallengeByIdIntegrationTest {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findChallengeById: SqliteFindChallengeById
-
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findChallengeById = SqliteFindChallengeById(jdbc, mapper)
+val SqliteFindChallengeByIdITSuite by testSuite {
+    test("finds a stored challenge with its fields intact") {
+        val (storeChallenge, findChallengeById) = newSqliteAdapters()
+        val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
+        storeChallenge handle StoreChallenge.Command(c)
+        val found = findChallengeById answer FindChallengeById.Query(c.id)
+        found.shouldNotBeNull()
+        found.id shouldBe c.id
+        found.secretPrompt().text shouldBe "pixel art cat"
+        found.lives.remaining shouldBe 5
     }
 
-    @Test
-    fun `finds a stored challenge with its fields intact`() =
-        runTest {
-            // Given
-            val c = mediumChallenge(lives = 5.lives(), prompt = "pixel art cat".asPrompt())
-            storeChallenge handle StoreChallenge.Command(c)
-
-            // When
-            val found = findChallengeById answer FindChallengeById.Query(c.id)
-
-            // Then
-            assertNotNull(found)
-            assertEquals(c.id, found.id)
-            assertEquals("pixel art cat", found.secretPrompt().text)
-            assertEquals(5, found.lives.remaining)
-        }
-
-    @Test
-    fun `returns null for an unknown id`() =
-        runTest {
-            // Given
-            val unknownId = aChallengeId()
-
-            // When
-            val found = findChallengeById answer FindChallengeById.Query(unknownId)
-
-            // Then
-            assertNull(found)
-        }
+    test("returns null for an unknown id") {
+        val (_, findChallengeById) = newSqliteAdapters()
+        val unknownId = aChallengeId()
+        val found = findChallengeById answer FindChallengeById.Query(unknownId)
+        found.shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
@@ -3,6 +3,9 @@ package com.yonatankarp.beatthemachine.output.persistence.sqlite
 import com.yonatankarp.beatthemachine.application.port.output.FindPendingChallenges
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
@@ -10,13 +13,17 @@ import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 
 val SqliteFindPendingChallengesITSuite by testSuite {
-    test("returns only challenges whose picture is pending") {
-        val (storeChallenge, _, findPendingChallenges) = newSqliteAdapters()
-        val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending one".asPrompt()))
-        val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending two".asPrompt()))
-        storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
-        storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
-        val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
-        ids shouldBe setOf(pendingA.id, pendingB.id)
+    given("challenges with pending, ready and failed pictures") {
+        whenever("querying the pending challenges") {
+            then("it returns only challenges whose picture is pending") {
+                val (storeChallenge, _, findPendingChallenges) = newSqliteAdapters()
+                val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending one".asPrompt()))
+                val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending two".asPrompt()))
+                storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
+                storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
+                val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
+                ids shouldBe setOf(pendingA.id, pendingB.id)
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPendingChallengesIntegrationTest.kt
@@ -6,36 +6,17 @@ import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
 
-class SqliteFindPendingChallengesIntegrationTest {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findPendingChallenges: SqliteFindPendingChallenges
-
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findPendingChallenges = SqliteFindPendingChallenges(jdbc, mapper)
+val SqliteFindPendingChallengesITSuite by testSuite {
+    test("returns only challenges whose picture is pending") {
+        val (storeChallenge, _, findPendingChallenges) = newSqliteAdapters()
+        val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending one".asPrompt()))
+        val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending two".asPrompt()))
+        storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
+        storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
+        val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
+        ids shouldBe setOf(pendingA.id, pendingB.id)
     }
-
-    @Test
-    fun `returns only challenges whose picture is pending`() =
-        runTest {
-            // Given
-            val pendingA = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending one".asPrompt()))
-            val pendingB = storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "pending two".asPrompt()))
-            storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()))
-            storeChallenge handle StoreChallenge.Command(mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()))
-
-            // When
-            val ids = (findPendingChallenges answer FindPendingChallenges.Query).map { it.id }.toSet()
-
-            // Then
-            assertEquals(setOf(pendingA.id, pendingB.id), ids)
-        }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPictureIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPictureIT.kt
@@ -2,22 +2,33 @@ package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
 val SqliteFindPictureITSuite by testSuite {
-    test("round-trips the bytes and content type") {
-        val (_, _, _, storePicture, findPicture) = newSqliteAdapters()
-        val bytes = byteArrayOf(1, 2, 3, 4)
-        val id = storePicture handle StorePicture.Command(bytes, "image/png")
-        val loaded = (findPicture answer FindPicture.Query(id))!!
-        loaded.contentType shouldBe "image/png"
-        bytes.contentEquals(loaded.bytes) shouldBe true
+    given("a stored picture") {
+        whenever("loading it by id") {
+            then("it round-trips the bytes and content type") {
+                val (_, _, _, storePicture, findPicture) = newSqliteAdapters()
+                val bytes = byteArrayOf(1, 2, 3, 4)
+                val id = storePicture handle StorePicture.Command(bytes, "image/png")
+                val loaded = (findPicture answer FindPicture.Query(id))!!
+                loaded.contentType shouldBe "image/png"
+                bytes.contentEquals(loaded.bytes) shouldBe true
+            }
+        }
     }
 
-    test("answer returns null for unknown id") {
-        val (_, _, _, _, findPicture) = newSqliteAdapters()
-        (findPicture answer FindPicture.Query("missing")).shouldBeNull()
+    given("an unknown id") {
+        whenever("loading the picture") {
+            then("it returns null") {
+                val (_, _, _, _, findPicture) = newSqliteAdapters()
+                (findPicture answer FindPicture.Query("missing")).shouldBeNull()
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPictureIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteFindPictureIT.kt
@@ -2,36 +2,22 @@ package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
 import com.yonatankarp.beatthemachine.application.port.output.FindPicture
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 
-class SqliteFindPictureIT {
-    private val jdbc = newSqliteJdbc()
-    private val storePicture = SqliteStorePicture(jdbc)
-    private val findPicture = SqliteFindPicture(jdbc)
+val SqliteFindPictureITSuite by testSuite {
+    test("round-trips the bytes and content type") {
+        val (_, _, _, storePicture, findPicture) = newSqliteAdapters()
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val id = storePicture handle StorePicture.Command(bytes, "image/png")
+        val loaded = (findPicture answer FindPicture.Query(id))!!
+        loaded.contentType shouldBe "image/png"
+        bytes.contentEquals(loaded.bytes) shouldBe true
+    }
 
-    @Test
-    fun `round-trips the bytes and content type`() =
-        runTest {
-            // Given
-            val bytes = byteArrayOf(1, 2, 3, 4)
-
-            // When
-            val id = storePicture handle StorePicture.Command(bytes, "image/png")
-            val loaded = (findPicture answer FindPicture.Query(id))!!
-
-            // Then
-            assertEquals("image/png", loaded.contentType)
-            assertTrue(bytes.contentEquals(loaded.bytes))
-        }
-
-    @Test
-    fun `answer returns null for unknown id`() =
-        runTest {
-            // When / Then
-            assertNull(findPicture answer FindPicture.Query("missing"))
-        }
+    test("answer returns null for unknown id") {
+        val (_, _, _, _, findPicture) = newSqliteAdapters()
+        (findPicture answer FindPicture.Query("missing")).shouldBeNull()
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
@@ -7,7 +7,10 @@ import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
 import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
@@ -17,50 +20,68 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 val SqliteStoreChallengeITSuite by testSuite {
-    test("stores a fresh challenge and bumps the version") {
-        val (storeChallenge) = newSqliteAdapters()
-        val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
-        val saved = storeChallenge handle StoreChallenge.Command(challenge)
-        saved.version shouldBe 1L
-    }
-
-    test("allows sequential stores with updated versions") {
-        val (storeChallenge) = newSqliteAdapters()
-        val challenge = mediumChallenge(prompt = "sequential".asPrompt())
-        val v1 = storeChallenge handle StoreChallenge.Command(challenge)
-        val v2 = storeChallenge handle StoreChallenge.Command(v1)
-        v1.version shouldBe 1L
-        v2.version shouldBe 2L
-    }
-
-    test("rejects a stale version on second store") {
-        val (storeChallenge) = newSqliteAdapters()
-        val c = mediumChallenge()
-        storeChallenge handle StoreChallenge.Command(c)
-        shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
-    }
-
-    test("persists all difficulty levels") {
-        val (storeChallenge, findChallengeById) = newSqliteAdapters()
-        Difficulty.entries.forEach { diff ->
-            val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
-            storeChallenge handle StoreChallenge.Command(c)
-            val found = findChallengeById answer FindChallengeById.Query(c.id)
-            found.shouldNotBeNull()
-            found.difficulty shouldBe diff
+    given("a fresh challenge") {
+        whenever("storing it") {
+            then("it stores the challenge and bumps the version") {
+                val (storeChallenge) = newSqliteAdapters()
+                val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
+                val saved = storeChallenge handle StoreChallenge.Command(challenge)
+                saved.version shouldBe 1L
+            }
         }
     }
 
-    test("persists picture states correctly") {
-        val (storeChallenge, findChallengeById) = newSqliteAdapters()
-        val pending = mediumChallenge(prompt = "pending pic".asPrompt())
-        val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
-        val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
-        storeChallenge handle StoreChallenge.Command(pending)
-        storeChallenge handle StoreChallenge.Command(ready)
-        storeChallenge handle StoreChallenge.Command(failed)
-        (findChallengeById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Pending
-        (findChallengeById answer FindChallengeById.Query(ready.id))?.picture shouldBe Picture.Ready("https://example.com/img.png")
-        (findChallengeById answer FindChallengeById.Query(failed.id))?.picture shouldBe Picture.Failed
+    given("a stored challenge") {
+        whenever("storing it again sequentially") {
+            then("it allows sequential stores with updated versions") {
+                val (storeChallenge) = newSqliteAdapters()
+                val challenge = mediumChallenge(prompt = "sequential".asPrompt())
+                val v1 = storeChallenge handle StoreChallenge.Command(challenge)
+                val v2 = storeChallenge handle StoreChallenge.Command(v1)
+                v1.version shouldBe 1L
+                v2.version shouldBe 2L
+            }
+        }
+
+        whenever("storing a stale version on second store") {
+            then("it rejects the stale version") {
+                val (storeChallenge) = newSqliteAdapters()
+                val c = mediumChallenge()
+                storeChallenge handle StoreChallenge.Command(c)
+                shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+            }
+        }
+    }
+
+    given("challenges of every difficulty level") {
+        whenever("storing and reloading them") {
+            then("it persists all difficulty levels") {
+                val (storeChallenge, findChallengeById) = newSqliteAdapters()
+                Difficulty.entries.forEach { diff ->
+                    val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
+                    storeChallenge handle StoreChallenge.Command(c)
+                    val found = findChallengeById answer FindChallengeById.Query(c.id)
+                    found.shouldNotBeNull()
+                    found.difficulty shouldBe diff
+                }
+            }
+        }
+    }
+
+    given("challenges with pending, ready and failed pictures") {
+        whenever("storing and reloading them") {
+            then("it persists picture states correctly") {
+                val (storeChallenge, findChallengeById) = newSqliteAdapters()
+                val pending = mediumChallenge(prompt = "pending pic".asPrompt())
+                val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
+                val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
+                storeChallenge handle StoreChallenge.Command(pending)
+                storeChallenge handle StoreChallenge.Command(ready)
+                storeChallenge handle StoreChallenge.Command(failed)
+                (findChallengeById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Pending
+                (findChallengeById answer FindChallengeById.Query(ready.id))?.picture shouldBe Picture.Ready("https://example.com/img.png")
+                (findChallengeById answer FindChallengeById.Query(failed.id))?.picture shouldBe Picture.Failed
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
@@ -11,99 +11,56 @@ import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 
-class SqliteStoreChallengeIntegrationTest {
-    private lateinit var storeChallenge: SqliteStoreChallenge
-    private lateinit var findChallengeById: SqliteFindChallengeById
-
-    @BeforeEach
-    fun setup() {
-        val jdbc = newSqliteJdbc()
-        val mapper = ChallengeRowMapper()
-        storeChallenge = SqliteStoreChallenge(jdbc, mapper)
-        findChallengeById = SqliteFindChallengeById(jdbc, mapper)
+val SqliteStoreChallengeITSuite by testSuite {
+    test("stores a fresh challenge and bumps the version") {
+        val (storeChallenge) = newSqliteAdapters()
+        val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
+        val saved = storeChallenge handle StoreChallenge.Command(challenge)
+        saved.version shouldBe 1L
     }
 
-    @Test
-    fun `stores a fresh challenge and bumps the version`() =
-        runTest {
-            // Given
-            val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
+    test("allows sequential stores with updated versions") {
+        val (storeChallenge) = newSqliteAdapters()
+        val challenge = mediumChallenge(prompt = "sequential".asPrompt())
+        val v1 = storeChallenge handle StoreChallenge.Command(challenge)
+        val v2 = storeChallenge handle StoreChallenge.Command(v1)
+        v1.version shouldBe 1L
+        v2.version shouldBe 2L
+    }
 
-            // When
-            val saved = storeChallenge handle StoreChallenge.Command(challenge)
+    test("rejects a stale version on second store") {
+        val (storeChallenge) = newSqliteAdapters()
+        val c = mediumChallenge()
+        storeChallenge handle StoreChallenge.Command(c)
+        shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+    }
 
-            // Then
-            assertEquals(1L, saved.version)
-        }
-
-    @Test
-    fun `allows sequential stores with updated versions`() =
-        runTest {
-            // Given
-            val challenge = mediumChallenge(prompt = "sequential".asPrompt())
-
-            // When
-            val v1 = storeChallenge handle StoreChallenge.Command(challenge)
-            val v2 = storeChallenge handle StoreChallenge.Command(v1)
-
-            // Then
-            assertEquals(1L, v1.version)
-            assertEquals(2L, v2.version)
-        }
-
-    @Test
-    fun `rejects a stale version on second store`() =
-        runTest {
-            // Given
-            val c = mediumChallenge()
+    test("persists all difficulty levels") {
+        val (storeChallenge, findChallengeById) = newSqliteAdapters()
+        Difficulty.entries.forEach { diff ->
+            val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
             storeChallenge handle StoreChallenge.Command(c)
-
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+            val found = findChallengeById answer FindChallengeById.Query(c.id)
+            found.shouldNotBeNull()
+            found.difficulty shouldBe diff
         }
+    }
 
-    @Test
-    fun `persists all difficulty levels`() =
-        runTest {
-            // Given
-            val difficulties = Difficulty.entries
-
-            // When / Then
-            difficulties.forEach { diff ->
-                val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
-                storeChallenge handle StoreChallenge.Command(c)
-                val found = findChallengeById answer FindChallengeById.Query(c.id)
-                assertNotNull(found)
-                assertEquals(diff, found.difficulty)
-            }
-        }
-
-    @Test
-    fun `persists picture states correctly`() =
-        runTest {
-            // Given
-            val pending = mediumChallenge(prompt = "pending pic".asPrompt())
-            val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
-            val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
-
-            // When
-            storeChallenge handle StoreChallenge.Command(pending)
-            storeChallenge handle StoreChallenge.Command(ready)
-            storeChallenge handle StoreChallenge.Command(failed)
-
-            // Then
-            assertEquals(Picture.Pending, (findChallengeById answer FindChallengeById.Query(pending.id))?.picture)
-            assertEquals(
-                Picture.Ready("https://example.com/img.png"),
-                (findChallengeById answer FindChallengeById.Query(ready.id))?.picture,
-            )
-            assertEquals(Picture.Failed, (findChallengeById answer FindChallengeById.Query(failed.id))?.picture)
-        }
+    test("persists picture states correctly") {
+        val (storeChallenge, findChallengeById) = newSqliteAdapters()
+        val pending = mediumChallenge(prompt = "pending pic".asPrompt())
+        val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
+        val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
+        storeChallenge handle StoreChallenge.Command(pending)
+        storeChallenge handle StoreChallenge.Command(ready)
+        storeChallenge handle StoreChallenge.Command(failed)
+        (findChallengeById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Pending
+        (findChallengeById answer FindChallengeById.Query(ready.id))?.picture shouldBe Picture.Ready("https://example.com/img.png")
+        (findChallengeById answer FindChallengeById.Query(failed.id))?.picture shouldBe Picture.Failed
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStorePictureIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStorePictureIT.kt
@@ -1,40 +1,26 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
 
-class SqliteStorePictureIT {
-    private val jdbc = newSqliteJdbc()
-    private val storePicture = SqliteStorePicture(jdbc)
+val SqliteStorePictureITSuite by testSuite {
+    test("handle returns an id and writes to picture table") {
+        val adapters = newSqliteAdapters()
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val id = adapters.storePicture handle StorePicture.Command(bytes, "image/png")
+        id.shouldNotBeBlank()
+        val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
+        pictureRows shouldBe 1
+    }
 
-    @Test
-    fun `handle returns an id and writes to picture table`() =
-        runTest {
-            // Given
-            val bytes = byteArrayOf(1, 2, 3, 4)
-
-            // When
-            val id = storePicture handle StorePicture.Command(bytes, "image/png")
-
-            // Then
-            assertTrue(id.isNotBlank())
-            val pictureRows = jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
-            assertEquals(1, pictureRows)
-        }
-
-    @Test
-    fun `bytes live in the picture table, not on challenge`() =
-        runTest {
-            // Given / When
-            storePicture handle StorePicture.Command(byteArrayOf(1), "image/png")
-
-            // Then
-            val pictureRows = jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
-            val challengeRows = jdbc.queryForObject("SELECT COUNT(*) FROM challenge", Int::class.java)
-            assertEquals(1, pictureRows)
-            assertEquals(0, challengeRows)
-        }
+    test("bytes live in the picture table, not on challenge") {
+        val adapters = newSqliteAdapters()
+        adapters.storePicture handle StorePicture.Command(byteArrayOf(1), "image/png")
+        val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
+        val challengeRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM challenge", Int::class.java)
+        pictureRows shouldBe 1
+        challengeRows shouldBe 0
+    }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStorePictureIT.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStorePictureIT.kt
@@ -1,26 +1,33 @@
 package com.yonatankarp.beatthemachine.output.persistence.sqlite
 
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
 
 val SqliteStorePictureITSuite by testSuite {
-    test("handle returns an id and writes to picture table") {
-        val adapters = newSqliteAdapters()
-        val bytes = byteArrayOf(1, 2, 3, 4)
-        val id = adapters.storePicture handle StorePicture.Command(bytes, "image/png")
-        id.shouldNotBeBlank()
-        val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
-        pictureRows shouldBe 1
-    }
+    given("picture bytes and a content type") {
+        whenever("storing the picture") {
+            then("it returns an id and writes to the picture table") {
+                val adapters = newSqliteAdapters()
+                val bytes = byteArrayOf(1, 2, 3, 4)
+                val id = adapters.storePicture handle StorePicture.Command(bytes, "image/png")
+                id.shouldNotBeBlank()
+                val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
+                pictureRows shouldBe 1
+            }
 
-    test("bytes live in the picture table, not on challenge") {
-        val adapters = newSqliteAdapters()
-        adapters.storePicture handle StorePicture.Command(byteArrayOf(1), "image/png")
-        val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
-        val challengeRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM challenge", Int::class.java)
-        pictureRows shouldBe 1
-        challengeRows shouldBe 0
+            then("the bytes live in the picture table, not on challenge") {
+                val adapters = newSqliteAdapters()
+                adapters.storePicture handle StorePicture.Command(byteArrayOf(1), "image/png")
+                val pictureRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM picture", Int::class.java)
+                val challengeRows = adapters.jdbc.queryForObject("SELECT COUNT(*) FROM challenge", Int::class.java)
+                pictureRows shouldBe 1
+                challengeRows shouldBe 0
+            }
+        }
     }
 }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteTestSupport.kt
@@ -19,3 +19,25 @@ internal fun newSqliteJdbc(): JdbcTemplate {
         .forEach { jdbc.execute(it) }
     return jdbc
 }
+
+internal data class SqliteAdapters(
+    val storeChallenge: SqliteStoreChallenge,
+    val findChallengeById: SqliteFindChallengeById,
+    val findPendingChallenges: SqliteFindPendingChallenges,
+    val storePicture: SqliteStorePicture,
+    val findPicture: SqliteFindPicture,
+    val jdbc: JdbcTemplate,
+)
+
+internal fun newSqliteAdapters(): SqliteAdapters {
+    val jdbc = newSqliteJdbc()
+    val mapper = ChallengeRowMapper()
+    return SqliteAdapters(
+        storeChallenge = SqliteStoreChallenge(jdbc, mapper),
+        findChallengeById = SqliteFindChallengeById(jdbc, mapper),
+        findPendingChallenges = SqliteFindPendingChallenges(jdbc, mapper),
+        storePicture = SqliteStorePicture(jdbc),
+        findPicture = SqliteFindPicture(jdbc),
+        jdbc = jdbc,
+    )
+}

--- a/beat-the-machine-application/build.gradle.kts
+++ b/beat-the-machine-application/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jacoco
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.testballoon)
 }
 
 kotlin {
@@ -16,6 +17,18 @@ dependencies {
     testImplementation(libs.bundles.unit.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(testFixtures(project(":beat-the-machine-domain")))
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.withType<Test> {

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StorePictureCommandTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StorePictureCommandTest.kt
@@ -1,5 +1,8 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -7,32 +10,44 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 val StorePictureCommandSuite by testSuite {
-    test("commands with the same bytes and content type are equal") {
-        val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        val same = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        command shouldBe same
-        command.hashCode() shouldBe same.hashCode()
-    }
+    given("a StorePicture command") {
+        whenever("compared to one with the same bytes and content type") {
+            then("they are equal") {
+                val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                val same = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                command shouldBe same
+                command.hashCode() shouldBe same.hashCode()
+            }
+        }
 
-    test("a command equals itself") {
-        val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        (command.equals(command)).shouldBeTrue()
-    }
+        whenever("compared to itself") {
+            then("it is equal") {
+                val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                (command.equals(command)).shouldBeTrue()
+            }
+        }
 
-    test("a command does not equal a value of another type") {
-        val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        (command.equals("image/png")).shouldBeFalse()
-    }
+        whenever("compared to a value of another type") {
+            then("it is not equal") {
+                val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                (command.equals("image/png")).shouldBeFalse()
+            }
+        }
 
-    test("commands differing in content type are not equal") {
-        val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        val other = StorePicture.Command(byteArrayOf(1, 2, 3), "image/jpeg")
-        command shouldNotBe other
-    }
+        whenever("compared to one with a different content type") {
+            then("they are not equal") {
+                val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                val other = StorePicture.Command(byteArrayOf(1, 2, 3), "image/jpeg")
+                command shouldNotBe other
+            }
+        }
 
-    test("commands differing in bytes are not equal") {
-        val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-        val other = StorePicture.Command(byteArrayOf(9, 9, 9), "image/png")
-        command shouldNotBe other
+        whenever("compared to one with different bytes") {
+            then("they are not equal") {
+                val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
+                val other = StorePicture.Command(byteArrayOf(9, 9, 9), "image/png")
+                command shouldNotBe other
+            }
+        }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StorePictureCommandTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StorePictureCommandTest.kt
@@ -1,58 +1,38 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
-class StorePictureCommandTest {
-    @Test
-    fun `commands with the same bytes and content type are equal`() {
-        // Given
+val StorePictureCommandSuite by testSuite {
+    test("commands with the same bytes and content type are equal") {
         val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
         val same = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertEquals(command, same)
-        assertEquals(command.hashCode(), same.hashCode())
+        command shouldBe same
+        command.hashCode() shouldBe same.hashCode()
     }
 
-    @Test
-    fun `a command equals itself`() {
-        // Given
+    test("a command equals itself") {
         val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertTrue(command.equals(command))
+        (command.equals(command)).shouldBeTrue()
     }
 
-    @Test
-    fun `a command does not equal a value of another type`() {
-        // Given
+    test("a command does not equal a value of another type") {
         val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertFalse(command.equals("image/png"))
+        (command.equals("image/png")).shouldBeFalse()
     }
 
-    @Test
-    fun `commands differing in content type are not equal`() {
-        // Given
+    test("commands differing in content type are not equal") {
         val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
         val other = StorePicture.Command(byteArrayOf(1, 2, 3), "image/jpeg")
-
-        // Then
-        assertNotEquals(command, other)
+        command shouldNotBe other
     }
 
-    @Test
-    fun `commands differing in bytes are not equal`() {
-        // Given
+    test("commands differing in bytes are not equal") {
         val command = StorePicture.Command(byteArrayOf(1, 2, 3), "image/png")
         val other = StorePicture.Command(byteArrayOf(9, 9, 9), "image/png")
-
-        // Then
-        assertNotEquals(command, other)
+        command shouldNotBe other
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoredImageTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoredImageTest.kt
@@ -1,5 +1,8 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -7,32 +10,44 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 val StoredImageSuite by testSuite {
-    test("images with the same bytes and content type are equal") {
-        val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        val same = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        image shouldBe same
-        image.hashCode() shouldBe same.hashCode()
-    }
+    given("a StoredImage") {
+        whenever("compared to one with the same bytes and content type") {
+            then("they are equal") {
+                val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                val same = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                image shouldBe same
+                image.hashCode() shouldBe same.hashCode()
+            }
+        }
 
-    test("an image equals itself") {
-        val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        (image.equals(image)).shouldBeTrue()
-    }
+        whenever("compared to itself") {
+            then("it is equal") {
+                val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                (image.equals(image)).shouldBeTrue()
+            }
+        }
 
-    test("an image does not equal a value of another type") {
-        val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        (image.equals("image/png")).shouldBeFalse()
-    }
+        whenever("compared to a value of another type") {
+            then("it is not equal") {
+                val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                (image.equals("image/png")).shouldBeFalse()
+            }
+        }
 
-    test("images differing in content type are not equal") {
-        val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        val other = StoredImage(byteArrayOf(1, 2, 3), "image/jpeg")
-        image shouldNotBe other
-    }
+        whenever("compared to one with a different content type") {
+            then("they are not equal") {
+                val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                val other = StoredImage(byteArrayOf(1, 2, 3), "image/jpeg")
+                image shouldNotBe other
+            }
+        }
 
-    test("images differing in bytes are not equal") {
-        val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        val other = StoredImage(byteArrayOf(9, 9, 9), "image/png")
-        image shouldNotBe other
+        whenever("compared to one with different bytes") {
+            then("they are not equal") {
+                val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                val other = StoredImage(byteArrayOf(9, 9, 9), "image/png")
+                image shouldNotBe other
+            }
+        }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoredImageTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/port/output/StoredImageTest.kt
@@ -1,58 +1,38 @@
 package com.yonatankarp.beatthemachine.application.port.output
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
-class StoredImageTest {
-    @Test
-    fun `images with the same bytes and content type are equal`() {
-        // Given
+val StoredImageSuite by testSuite {
+    test("images with the same bytes and content type are equal") {
         val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
         val same = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertEquals(image, same)
-        assertEquals(image.hashCode(), same.hashCode())
+        image shouldBe same
+        image.hashCode() shouldBe same.hashCode()
     }
 
-    @Test
-    fun `an image equals itself`() {
-        // Given
+    test("an image equals itself") {
         val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertTrue(image.equals(image))
+        (image.equals(image)).shouldBeTrue()
     }
 
-    @Test
-    fun `an image does not equal a value of another type`() {
-        // Given
+    test("an image does not equal a value of another type") {
         val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-
-        // Then
-        assertFalse(image.equals("image/png"))
+        (image.equals("image/png")).shouldBeFalse()
     }
 
-    @Test
-    fun `images differing in content type are not equal`() {
-        // Given
+    test("images differing in content type are not equal") {
         val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
         val other = StoredImage(byteArrayOf(1, 2, 3), "image/jpeg")
-
-        // Then
-        assertNotEquals(image, other)
+        image shouldNotBe other
     }
 
-    @Test
-    fun `images differing in bytes are not equal`() {
-        // Given
+    test("images differing in bytes are not equal") {
         val image = StoredImage(byteArrayOf(1, 2, 3), "image/png")
         val other = StoredImage(byteArrayOf(9, 9, 9), "image/png")
-
-        // Then
-        assertNotEquals(image, other)
+        image shouldNotBe other
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -4,45 +4,29 @@ import com.yonatankarp.beatthemachine.application.exception.ChallengeNotFound
 import com.yonatankarp.beatthemachine.application.port.input.ForfeitChallenge
 import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
-import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class ForfeitChallengeUseCaseTest {
-    private val store = FakeChallengeStore()
+val ForfeitChallengeUseSuite by testSuite {
+    test("forfeit loads the challenge, sets LOST, and persists it") {
+        val store = FakeChallengeStore()
+        val c = store handle StoreChallenge.Command(mediumChallenge())
+        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+        val result = forfeitChallenge handle ForfeitChallenge.Command(c.id)
+        result.status shouldBe ChallengeStatus.LOST
+        (store answer FindChallengeById.Query(c.id))?.status shouldBe ChallengeStatus.LOST
+    }
 
-    private suspend fun seed(): Challenge = store handle StoreChallenge.Command(mediumChallenge())
-
-    @Test
-    fun `forfeit loads the challenge, sets LOST, and persists it`() =
-        runTest {
-            // Given
-            val c = seed()
-            val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-
-            // When
-            val result = forfeitChallenge handle ForfeitChallenge.Command(c.id)
-
-            // Then
-            assertEquals(ChallengeStatus.LOST, result.status)
-            assertEquals(ChallengeStatus.LOST, (store answer FindChallengeById.Query(c.id))?.status)
+    test("an unknown challenge throws ChallengeNotFound") {
+        val store = FakeChallengeStore()
+        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+        val unknownId = aChallengeId()
+        shouldThrow<ChallengeNotFound> {
+            forfeitChallenge handle ForfeitChallenge.Command(unknownId)
         }
-
-    @Test
-    fun `an unknown challenge throws ChallengeNotFound`() =
-        runTest {
-            // Given
-            val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-            val unknownId = aChallengeId()
-
-            // When / Then
-            assertFailsWith<ChallengeNotFound> {
-                forfeitChallenge handle ForfeitChallenge.Command(unknownId)
-            }
-        }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -6,27 +6,38 @@ import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 
 val ForfeitChallengeUseSuite by testSuite {
-    test("forfeit loads the challenge, sets LOST, and persists it") {
-        val store = FakeChallengeStore()
-        val c = store handle StoreChallenge.Command(mediumChallenge())
-        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-        val result = forfeitChallenge handle ForfeitChallenge.Command(c.id)
-        result.status shouldBe ChallengeStatus.LOST
-        (store answer FindChallengeById.Query(c.id))?.status shouldBe ChallengeStatus.LOST
+    given("a stored challenge") {
+        whenever("forfeiting it") {
+            then("it sets the status to LOST and persists it") {
+                val store = FakeChallengeStore()
+                val c = store handle StoreChallenge.Command(mediumChallenge())
+                val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+                val result = forfeitChallenge handle ForfeitChallenge.Command(c.id)
+                result.status shouldBe ChallengeStatus.LOST
+                (store answer FindChallengeById.Query(c.id))?.status shouldBe ChallengeStatus.LOST
+            }
+        }
     }
 
-    test("an unknown challenge throws ChallengeNotFound") {
-        val store = FakeChallengeStore()
-        val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-        val unknownId = aChallengeId()
-        shouldThrow<ChallengeNotFound> {
-            forfeitChallenge handle ForfeitChallenge.Command(unknownId)
+    given("an unknown challenge") {
+        whenever("forfeiting it") {
+            then("it throws ChallengeNotFound") {
+                val store = FakeChallengeStore()
+                val forfeitChallenge = ForfeitChallengeUseCase(store, store)
+                val unknownId = aChallengeId()
+                shouldThrow<ChallengeNotFound> {
+                    forfeitChallenge handle ForfeitChallenge.Command(unknownId)
+                }
+            }
         }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -6,35 +6,23 @@ import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class GetChallengeUseCaseTest {
-    private val store = FakeChallengeStore()
-    private val getChallenge = GetChallengeUseCase(store)
+val GetChallengeSuite by testSuite {
+    test("returns a challenge that exists") {
+        val store = FakeChallengeStore()
+        val getChallenge = GetChallengeUseCase(store)
+        val challenge = store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
+        val result = getChallenge answer GetChallenge.Query(challenge.id)
+        result shouldBe challenge
+    }
 
-    @Test
-    fun `returns a challenge that exists`() =
-        runTest {
-            // Given
-            val challenge = store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
-
-            // When
-            val result = getChallenge answer GetChallenge.Query(challenge.id)
-
-            // Then
-            assertEquals(challenge, result)
-        }
-
-    @Test
-    fun `throws ChallengeNotFound for an unknown id`() =
-        runTest {
-            // Given
-            val unknownId = aChallengeId()
-
-            // When / Then
-            assertFailsWith<ChallengeNotFound> { getChallenge answer GetChallenge.Query(unknownId) }
-        }
+    test("throws ChallengeNotFound for an unknown id") {
+        val store = FakeChallengeStore()
+        val getChallenge = GetChallengeUseCase(store)
+        val unknownId = aChallengeId()
+        shouldThrow<ChallengeNotFound> { getChallenge answer GetChallenge.Query(unknownId) }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -5,24 +5,35 @@ import com.yonatankarp.beatthemachine.application.port.input.GetChallenge
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 
 val GetChallengeSuite by testSuite {
-    test("returns a challenge that exists") {
-        val store = FakeChallengeStore()
-        val getChallenge = GetChallengeUseCase(store)
-        val challenge = store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
-        val result = getChallenge answer GetChallenge.Query(challenge.id)
-        result shouldBe challenge
+    given("a stored challenge") {
+        whenever("getting it by id") {
+            then("it returns the challenge") {
+                val store = FakeChallengeStore()
+                val getChallenge = GetChallengeUseCase(store)
+                val challenge = store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
+                val result = getChallenge answer GetChallenge.Query(challenge.id)
+                result shouldBe challenge
+            }
+        }
     }
 
-    test("throws ChallengeNotFound for an unknown id") {
-        val store = FakeChallengeStore()
-        val getChallenge = GetChallengeUseCase(store)
-        val unknownId = aChallengeId()
-        shouldThrow<ChallengeNotFound> { getChallenge answer GetChallenge.Query(unknownId) }
+    given("an unknown id") {
+        whenever("getting the challenge") {
+            then("it throws ChallengeNotFound") {
+                val store = FakeChallengeStore()
+                val getChallenge = GetChallengeUseCase(store)
+                val unknownId = aChallengeId()
+                shouldThrow<ChallengeNotFound> { getChallenge answer GetChallenge.Query(unknownId) }
+            }
+        }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -10,44 +10,60 @@ import com.yonatankarp.beatthemachine.domain.valueobject.GuessOutcome
 import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 
 val MakeGuessUseSuite by testSuite {
-    test("a hit is persisted") {
-        val store = FakeChallengeStore()
-        val c = store handle StoreChallenge.Command(mediumChallenge())
-        val makeGuess = MakeGuessUseCase(store, store)
-        val guess = "hello".asGuess()
-        val (updated, outcome) = makeGuess handle MakeGuess.Command(c.id, guess)
-        outcome shouldBe GuessOutcome.HIT
-        updated.maskedPrompt().tokens[0] shouldBe MaskedToken.Revealed("hello")
-        (store answer FindChallengeById.Query(c.id))?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
-    }
-
-    test("an unknown challenge throws ChallengeNotFound") {
-        val store = FakeChallengeStore()
-        val makeGuess = MakeGuessUseCase(store, store)
-        val unknownId = aChallengeId()
-        val guess = "hello".asGuess()
-        shouldThrow<ChallengeNotFound> {
-            makeGuess handle MakeGuess.Command(unknownId, guess)
+    given("a stored challenge") {
+        whenever("a correct guess is made") {
+            then("the hit is returned and persisted") {
+                val store = FakeChallengeStore()
+                val c = store handle StoreChallenge.Command(mediumChallenge())
+                val makeGuess = MakeGuessUseCase(store, store)
+                val guess = "hello".asGuess()
+                val (updated, outcome) = makeGuess handle MakeGuess.Command(c.id, guess)
+                outcome shouldBe GuessOutcome.HIT
+                updated.maskedPrompt().tokens[0] shouldBe MaskedToken.Revealed("hello")
+                (store answer FindChallengeById.Query(c.id))?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
+            }
         }
     }
 
-    test("an optimistic-lock conflict on store propagates") {
-        val store = FakeChallengeStore()
-        val c = store handle StoreChallenge.Command(mediumChallenge())
-        val conflicting =
-            object : StoreChallenge {
-                override suspend fun handle(command: StoreChallenge.Command): Challenge = throw OptimisticLockConflict(command.challenge.id)
+    given("an unknown challenge") {
+        whenever("a guess is made") {
+            then("it throws ChallengeNotFound") {
+                val store = FakeChallengeStore()
+                val makeGuess = MakeGuessUseCase(store, store)
+                val unknownId = aChallengeId()
+                val guess = "hello".asGuess()
+                shouldThrow<ChallengeNotFound> {
+                    makeGuess handle MakeGuess.Command(unknownId, guess)
+                }
             }
-        val makeGuess = MakeGuessUseCase(store, conflicting)
-        val guess = "hello".asGuess()
-        shouldThrow<OptimisticLockConflict> {
-            makeGuess handle MakeGuess.Command(c.id, guess)
+        }
+    }
+
+    given("a store that conflicts on write") {
+        whenever("a guess is made") {
+            then("the optimistic-lock conflict propagates") {
+                val store = FakeChallengeStore()
+                val c = store handle StoreChallenge.Command(mediumChallenge())
+                val conflicting =
+                    object : StoreChallenge {
+                        override suspend fun handle(command: StoreChallenge.Command): Challenge =
+                            throw OptimisticLockConflict(command.challenge.id)
+                    }
+                val makeGuess = MakeGuessUseCase(store, conflicting)
+                val guess = "hello".asGuess()
+                shouldThrow<OptimisticLockConflict> {
+                    makeGuess handle MakeGuess.Command(c.id, guess)
+                }
+            }
         }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -11,63 +11,43 @@ import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class MakeGuessUseCaseTest {
-    private val store = FakeChallengeStore()
+val MakeGuessUseSuite by testSuite {
+    test("a hit is persisted") {
+        val store = FakeChallengeStore()
+        val c = store handle StoreChallenge.Command(mediumChallenge())
+        val makeGuess = MakeGuessUseCase(store, store)
+        val guess = "hello".asGuess()
+        val (updated, outcome) = makeGuess handle MakeGuess.Command(c.id, guess)
+        outcome shouldBe GuessOutcome.HIT
+        updated.maskedPrompt().tokens[0] shouldBe MaskedToken.Revealed("hello")
+        (store answer FindChallengeById.Query(c.id))?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
+    }
 
-    private suspend fun seed(): Challenge = store handle StoreChallenge.Command(mediumChallenge())
-
-    @Test
-    fun `a hit is persisted`() =
-        runTest {
-            // Given
-            val c = seed()
-            val makeGuess = MakeGuessUseCase(store, store)
-            val guess = "hello".asGuess()
-
-            // When
-            val (updated, outcome) = makeGuess handle MakeGuess.Command(c.id, guess)
-
-            // Then
-            assertEquals(GuessOutcome.HIT, outcome)
-            assertEquals(MaskedToken.Revealed("hello"), updated.maskedPrompt().tokens[0])
-            assertEquals(MaskedToken.Revealed("hello"), (store answer FindChallengeById.Query(c.id))?.maskedPrompt()?.tokens?.get(0))
+    test("an unknown challenge throws ChallengeNotFound") {
+        val store = FakeChallengeStore()
+        val makeGuess = MakeGuessUseCase(store, store)
+        val unknownId = aChallengeId()
+        val guess = "hello".asGuess()
+        shouldThrow<ChallengeNotFound> {
+            makeGuess handle MakeGuess.Command(unknownId, guess)
         }
+    }
 
-    @Test
-    fun `an unknown challenge throws ChallengeNotFound`() =
-        runTest {
-            // Given
-            val makeGuess = MakeGuessUseCase(store, store)
-            val unknownId = aChallengeId()
-            val guess = "hello".asGuess()
-
-            // When / Then
-            assertFailsWith<ChallengeNotFound> {
-                makeGuess handle MakeGuess.Command(unknownId, guess)
+    test("an optimistic-lock conflict on store propagates") {
+        val store = FakeChallengeStore()
+        val c = store handle StoreChallenge.Command(mediumChallenge())
+        val conflicting =
+            object : StoreChallenge {
+                override suspend fun handle(command: StoreChallenge.Command): Challenge = throw OptimisticLockConflict(command.challenge.id)
             }
+        val makeGuess = MakeGuessUseCase(store, conflicting)
+        val guess = "hello".asGuess()
+        shouldThrow<OptimisticLockConflict> {
+            makeGuess handle MakeGuess.Command(c.id, guess)
         }
-
-    @Test
-    fun `an optimistic-lock conflict on store propagates`() =
-        runTest {
-            // Given
-            val c = seed()
-            val conflicting =
-                object : StoreChallenge {
-                    override suspend fun handle(command: StoreChallenge.Command): Challenge =
-                        throw OptimisticLockConflict(command.challenge.id)
-                }
-            val makeGuess = MakeGuessUseCase(store, conflicting)
-            val guess = "hello".asGuess()
-
-            // When / Then
-            assertFailsWith<OptimisticLockConflict> {
-                makeGuess handle MakeGuess.Command(c.id, guess)
-            }
-        }
+    }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -2,7 +2,6 @@ package com.yonatankarp.beatthemachine.application.usecase
 
 import com.yonatankarp.beatthemachine.application.port.input.StartChallenge
 import com.yonatankarp.beatthemachine.application.port.output.PromptSource
-import com.yonatankarp.beatthemachine.application.port.output.StoredImage
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeId
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
@@ -15,7 +14,6 @@ import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.mockk
 
@@ -47,19 +45,6 @@ val StartChallengeUseSuite by testSuite {
                 easy.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.EASY).remaining
                 medium.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining
                 hard.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.HARD).remaining
-            }
-        }
-    }
-
-    given("a StoredImage") {
-        whenever("compared by content") {
-            then("equality is content-based") {
-                val a = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-                val b = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-                val c = StoredImage(byteArrayOf(9), "image/png")
-                a shouldBe b
-                a shouldNotBe c
-                a.hashCode() shouldBe b.hashCode()
             }
         }
     }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -9,6 +9,9 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
@@ -20,34 +23,44 @@ val StartChallengeUseSuite by testSuite {
     val fakePrompt = "hello world".asPrompt()
     val prompts = mockk<PromptSource>().also { coEvery { it answer any() } returns fakePrompt }
 
-    test("starts a pending challenge and enqueues picture generation") {
-        val store = FakeChallengeStore()
-        val enqueued = mutableListOf<ChallengeId>()
-        val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
-        val challenge = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
-        challenge.picture shouldBe Picture.Pending
-        challenge.status shouldBe ChallengeStatus.IN_PROGRESS
-        enqueued shouldBe listOf(challenge.id)
-        store.byId.containsKey(challenge.id).shouldBeTrue()
+    given("a prompt source and store") {
+        whenever("starting a medium challenge") {
+            then("a pending challenge is created and picture generation is enqueued") {
+                val store = FakeChallengeStore()
+                val enqueued = mutableListOf<ChallengeId>()
+                val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
+                val challenge = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
+                challenge.picture shouldBe Picture.Pending
+                challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+                enqueued shouldBe listOf(challenge.id)
+                store.byId.containsKey(challenge.id).shouldBeTrue()
+            }
+        }
+
+        whenever("starting challenges of each difficulty") {
+            then("the starting lives scale with difficulty") {
+                val store = FakeChallengeStore()
+                val startChallenge = StartChallengeUseCase(prompts, store) {}
+                val easy = startChallenge handle StartChallenge.Command(Difficulty.EASY)
+                val medium = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
+                val hard = startChallenge handle StartChallenge.Command(Difficulty.HARD)
+                easy.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.EASY).remaining
+                medium.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining
+                hard.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.HARD).remaining
+            }
+        }
     }
 
-    test("starting lives scale with difficulty") {
-        val store = FakeChallengeStore()
-        val startChallenge = StartChallengeUseCase(prompts, store) {}
-        val easy = startChallenge handle StartChallenge.Command(Difficulty.EASY)
-        val medium = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
-        val hard = startChallenge handle StartChallenge.Command(Difficulty.HARD)
-        easy.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.EASY).remaining
-        medium.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining
-        hard.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.HARD).remaining
-    }
-
-    test("StoredImage equality is content-based") {
-        val a = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        val b = StoredImage(byteArrayOf(1, 2, 3), "image/png")
-        val c = StoredImage(byteArrayOf(9), "image/png")
-        a shouldBe b
-        a shouldNotBe c
-        a.hashCode() shouldBe b.hashCode()
+    given("a StoredImage") {
+        whenever("compared by content") {
+            then("equality is content-based") {
+                val a = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                val b = StoredImage(byteArrayOf(1, 2, 3), "image/png")
+                val c = StoredImage(byteArrayOf(9), "image/png")
+                a shouldBe b
+                a shouldNotBe c
+                a.hashCode() shouldBe b.hashCode()
+            }
+        }
     }
 }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -9,63 +9,45 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
-class StartChallengeUseCaseTest {
-    private val fakePrompt = "hello world".asPrompt()
-    private val prompts = mockk<PromptSource>().also { coEvery { it answer any() } returns fakePrompt }
-    private val store = FakeChallengeStore()
+val StartChallengeUseSuite by testSuite {
+    val fakePrompt = "hello world".asPrompt()
+    val prompts = mockk<PromptSource>().also { coEvery { it answer any() } returns fakePrompt }
 
-    @Test
-    fun `starts a pending challenge and enqueues picture generation`() =
-        runTest {
-            // Given
-            val enqueued = mutableListOf<ChallengeId>()
-            val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
+    test("starts a pending challenge and enqueues picture generation") {
+        val store = FakeChallengeStore()
+        val enqueued = mutableListOf<ChallengeId>()
+        val startChallenge = StartChallengeUseCase(prompts, store) { enqueued.add(it) }
+        val challenge = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
+        challenge.picture shouldBe Picture.Pending
+        challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+        enqueued shouldBe listOf(challenge.id)
+        store.byId.containsKey(challenge.id).shouldBeTrue()
+    }
 
-            // When
-            val challenge = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
+    test("starting lives scale with difficulty") {
+        val store = FakeChallengeStore()
+        val startChallenge = StartChallengeUseCase(prompts, store) {}
+        val easy = startChallenge handle StartChallenge.Command(Difficulty.EASY)
+        val medium = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
+        val hard = startChallenge handle StartChallenge.Command(Difficulty.HARD)
+        easy.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.EASY).remaining
+        medium.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining
+        hard.lives.remaining shouldBe Lives.forSecret(fakePrompt, Difficulty.HARD).remaining
+    }
 
-            // Then
-            assertEquals(Picture.Pending, challenge.picture)
-            assertEquals(ChallengeStatus.IN_PROGRESS, challenge.status)
-            assertEquals(listOf(challenge.id), enqueued)
-            assertTrue(store.byId.containsKey(challenge.id))
-        }
-
-    @Test
-    fun `starting lives scale with difficulty`() =
-        runTest {
-            // Given
-            val startChallenge = StartChallengeUseCase(prompts, store) {}
-
-            // When
-            val easy = startChallenge handle StartChallenge.Command(Difficulty.EASY)
-            val medium = startChallenge handle StartChallenge.Command(Difficulty.MEDIUM)
-            val hard = startChallenge handle StartChallenge.Command(Difficulty.HARD)
-
-            // Then
-            assertEquals(Lives.forSecret(fakePrompt, Difficulty.EASY).remaining, easy.lives.remaining)
-            assertEquals(Lives.forSecret(fakePrompt, Difficulty.MEDIUM).remaining, medium.lives.remaining)
-            assertEquals(Lives.forSecret(fakePrompt, Difficulty.HARD).remaining, hard.lives.remaining)
-        }
-
-    @Test
-    fun `StoredImage equality is content-based`() {
-        // Given
+    test("StoredImage equality is content-based") {
         val a = StoredImage(byteArrayOf(1, 2, 3), "image/png")
         val b = StoredImage(byteArrayOf(1, 2, 3), "image/png")
         val c = StoredImage(byteArrayOf(9), "image/png")
-
-        // When / Then
-        assertEquals(a, b)
-        assertNotEquals(a, c)
-        assertEquals(a.hashCode(), b.hashCode())
+        a shouldBe b
+        a shouldNotBe c
+        a.hashCode() shouldBe b.hashCode()
     }
 }

--- a/beat-the-machine-domain/build.gradle.kts
+++ b/beat-the-machine-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jacoco
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.testballoon)
     `java-test-fixtures`
 }
 
@@ -11,7 +12,21 @@ kotlin {
 }
 
 dependencies {
+    testFixturesApi(libs.testballoon.core)
+
     testImplementation(libs.bundles.unit.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.junit.platform") {
+            useVersion(
+                libs.versions.junit.platform.launcher
+                    .get(),
+            )
+        }
+    }
 }
 
 tasks.withType<Test> {

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -27,17 +27,23 @@ val ChallengeSuite by testSuite {
 
         whenever("a correct guess is made") {
             val (updated, outcome) = challenge.makeGuess("hello".asGuess())
-            then("outcome is HIT, status IN_PROGRESS, lives unchanged") {
+            then("the outcome is a hit") {
                 outcome shouldBe GuessOutcome.HIT
+            }
+            then("the challenge stays in progress") {
                 updated.status shouldBe ChallengeStatus.IN_PROGRESS
+            }
+            then("no life is lost") {
                 updated.lives.remaining shouldBe 3
             }
         }
 
         whenever("a wrong guess is made") {
             val (updated, outcome) = challenge.makeGuess("nope".asGuess())
-            then("outcome is MISS and one life is lost") {
+            then("the outcome is a miss") {
                 outcome shouldBe GuessOutcome.MISS
+            }
+            then("one life is lost") {
                 updated.lives.remaining shouldBe 2
             }
         }
@@ -45,16 +51,20 @@ val ChallengeSuite by testSuite {
         whenever("a duplicate guess is made") {
             val (afterFirst, _) = challenge.makeGuess("nope".asGuess())
             val (afterSecond, outcome) = afterFirst.makeGuess("Nope".asGuess())
-            then("outcome is DUPLICATE and no additional life is lost") {
+            then("the outcome is a duplicate") {
                 outcome shouldBe GuessOutcome.DUPLICATE
+            }
+            then("no additional life is lost") {
                 afterSecond.lives.remaining shouldBe 2
             }
         }
 
         whenever("a guess is made") {
-            then("the receiver is not mutated") {
-                challenge.makeGuess("nope".asGuess())
+            challenge.makeGuess("nope".asGuess())
+            then("the receiver lives are not mutated") {
                 challenge.lives.remaining shouldBe 3
+            }
+            then("the receiver guesses are not mutated") {
                 challenge.guesses.isEmpty().shouldBeTrue()
             }
         }
@@ -74,8 +84,10 @@ val ChallengeSuite by testSuite {
             val challenge = mediumChallenge()
             val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
             val (afterSecond, outcome) = afterFirst.makeGuess("world".asGuess())
-            then("outcome is HIT and status is BEATEN") {
+            then("the outcome is a hit") {
                 outcome shouldBe GuessOutcome.HIT
+            }
+            then("the status is beaten") {
                 afterSecond.status shouldBe ChallengeStatus.BEATEN
             }
         }
@@ -99,8 +111,10 @@ val ChallengeSuite by testSuite {
     given("a medium challenge") {
         whenever("forfeited") {
             val forfeited = mediumChallenge().forfeit()
-            then("status is LOST and all tokens are revealed") {
+            then("status is LOST") {
                 forfeited.status shouldBe ChallengeStatus.LOST
+            }
+            then("all tokens are revealed") {
                 forfeited
                     .maskedPrompt()
                     .tokens
@@ -111,9 +125,12 @@ val ChallengeSuite by testSuite {
 
         whenever("maskedPrompt after one hit") {
             val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
-            then("first token revealed, second hidden") {
+            then("the first token is revealed") {
                 val masked = afterHit.maskedPrompt()
                 masked.tokens[0] shouldBe MaskedToken.Revealed("hello")
+            }
+            then("the second token is hidden") {
+                val masked = afterHit.maskedPrompt()
                 masked.tokens[1] shouldBe MaskedToken.Hidden(5)
             }
         }
@@ -128,10 +145,16 @@ val ChallengeSuite by testSuite {
             val challenge = mediumChallenge()
             val newPicture = readyPicture("https://example.com/img.png")
             val updated = challenge.withPicture(newPicture)
-            then("picture updated, version same, original untouched, not same reference") {
+            then("the picture is updated") {
                 updated.picture shouldBe newPicture
+            }
+            then("the version is unchanged") {
                 updated.version shouldBe challenge.version
+            }
+            then("the original picture is still pending") {
                 challenge.picture shouldBe Picture.Pending
+            }
+            then("the updated challenge is a new instance") {
                 (challenge !== updated).shouldBeTrue()
             }
         }
@@ -140,9 +163,13 @@ val ChallengeSuite by testSuite {
     given("Challenge.start") {
         whenever("called with a prompt and lives") {
             val challenge = Challenge.start("hello world".asPrompt(), 6.lives())
-            then("defaults to pending picture and medium difficulty in progress") {
+            then("the picture defaults to pending") {
                 challenge.picture shouldBe Picture.Pending
+            }
+            then("the difficulty defaults to medium") {
                 challenge.difficulty shouldBe Difficulty.MEDIUM
+            }
+            then("the status is in progress") {
                 challenge.status shouldBe ChallengeStatus.IN_PROGRESS
             }
         }
@@ -162,12 +189,22 @@ val ChallengeSuite by testSuite {
                     difficulty = Difficulty.HARD,
                     version = 7L,
                 )
-            then("reconstitutes the challenge and preserves all fields") {
+            then("the secret prompt is preserved") {
                 challenge.secretPrompt() shouldBe prompt
+            }
+            then("the lives remaining is preserved") {
                 challenge.lives.remaining shouldBe 4
+            }
+            then("the status is preserved") {
                 challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+            }
+            then("the picture is preserved") {
                 challenge.picture shouldBe Picture.Failed
+            }
+            then("the difficulty is preserved") {
                 challenge.difficulty shouldBe Difficulty.HARD
+            }
+            then("the version is preserved") {
                 challenge.version shouldBe 7L
             }
         }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -10,211 +10,166 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
+import com.yonatankarp.beatthemachine.test.dsl.given
 import com.yonatankarp.beatthemachine.test.dsl.lives
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNotSame
-import kotlin.test.assertTrue
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class ChallengeTest {
-    @Test
-    fun `a correct guess reveals the word and stays in progress`() {
-        // Given
+val ChallengeSuite by testSuite {
+    given("a medium challenge with 3 lives") {
         val challenge = mediumChallenge(lives = 3.lives())
-        val guess = "hello".asGuess()
 
-        // When
-        val (updated, outcome) = challenge.makeGuess(guess)
+        whenever("a correct guess is made") {
+            val (updated, outcome) = challenge.makeGuess("hello".asGuess())
+            then("outcome is HIT, status IN_PROGRESS, lives unchanged") {
+                outcome shouldBe GuessOutcome.HIT
+                updated.status shouldBe ChallengeStatus.IN_PROGRESS
+                updated.lives.remaining shouldBe 3
+            }
+        }
 
-        // Then
-        assertEquals(GuessOutcome.HIT, outcome)
-        assertEquals(ChallengeStatus.IN_PROGRESS, updated.status)
-        assertEquals(3, updated.lives.remaining)
+        whenever("a wrong guess is made") {
+            val (updated, outcome) = challenge.makeGuess("nope".asGuess())
+            then("outcome is MISS and one life is lost") {
+                outcome shouldBe GuessOutcome.MISS
+                updated.lives.remaining shouldBe 2
+            }
+        }
+
+        whenever("a duplicate guess is made") {
+            val (afterFirst, _) = challenge.makeGuess("nope".asGuess())
+            val (afterSecond, outcome) = afterFirst.makeGuess("Nope".asGuess())
+            then("outcome is DUPLICATE and no additional life is lost") {
+                outcome shouldBe GuessOutcome.DUPLICATE
+                afterSecond.lives.remaining shouldBe 2
+            }
+        }
+
+        whenever("a guess is made") {
+            then("the receiver is not mutated") {
+                challenge.makeGuess("nope".asGuess())
+                challenge.lives.remaining shouldBe 3
+                challenge.guesses.isEmpty().shouldBeTrue()
+            }
+        }
     }
 
-    @Test
-    fun `a wrong guess costs a life`() {
-        // Given
-        val challenge = mediumChallenge(lives = 3.lives())
-        val guess = "nope".asGuess()
-
-        // When
-        val (updated, outcome) = challenge.makeGuess(guess)
-
-        // Then
-        assertEquals(GuessOutcome.MISS, outcome)
-        assertEquals(2, updated.lives.remaining)
+    given("a medium challenge with 1 life") {
+        whenever("a wrong guess is made") {
+            val (updated, _) = mediumChallenge(lives = 1.lives()).makeGuess("nope".asGuess())
+            then("status is LOST") {
+                updated.status shouldBe ChallengeStatus.LOST
+            }
+        }
     }
 
-    @Test
-    fun `guessing every word beats the machine`() {
-        // Given
-        val challenge = mediumChallenge()
-        val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
-
-        // When
-        val (afterSecond, outcome) = afterFirst.makeGuess("world".asGuess())
-
-        // Then
-        assertEquals(GuessOutcome.HIT, outcome)
-        assertEquals(ChallengeStatus.BEATEN, afterSecond.status)
+    given("guessing every word") {
+        whenever("all words are guessed") {
+            val challenge = mediumChallenge()
+            val (afterFirst, _) = challenge.makeGuess("hello".asGuess())
+            val (afterSecond, outcome) = afterFirst.makeGuess("world".asGuess())
+            then("outcome is HIT and status is BEATEN") {
+                outcome shouldBe GuessOutcome.HIT
+                afterSecond.status shouldBe ChallengeStatus.BEATEN
+            }
+        }
     }
 
-    @Test
-    fun `running out of lives loses the challenge`() {
-        // Given
-        val challenge = mediumChallenge(lives = 1.lives())
-        val guess = "nope".asGuess()
-
-        // When
-        val (updated, _) = challenge.makeGuess(guess)
-
-        // Then
-        assertEquals(ChallengeStatus.LOST, updated.status)
+    given("a finished challenge") {
+        whenever("makeGuess is called after the challenge is over") {
+            then("it is rejected") {
+                val (lost, _) = mediumChallenge(lives = 1.lives()).makeGuess("nope".asGuess())
+                shouldThrow<ChallengeAlreadyOver> { lost.makeGuess("hello".asGuess()) }
+            }
+        }
+        whenever("forfeit is called after the challenge is over") {
+            then("it is rejected") {
+                val forfeited = mediumChallenge().forfeit()
+                shouldThrow<ChallengeAlreadyOver> { forfeited.forfeit() }
+            }
+        }
     }
 
-    @Test
-    fun `a duplicate guess is a no-op and costs no life`() {
-        // Given
-        val challenge = mediumChallenge(lives = 3.lives())
-        val (afterFirst, _) = challenge.makeGuess("nope".asGuess())
+    given("a medium challenge") {
+        whenever("forfeited") {
+            val forfeited = mediumChallenge().forfeit()
+            then("status is LOST and all tokens are revealed") {
+                forfeited.status shouldBe ChallengeStatus.LOST
+                forfeited
+                    .maskedPrompt()
+                    .tokens
+                    .all { it is MaskedToken.Revealed }
+                    .shouldBeTrue()
+            }
+        }
 
-        // When
-        val (afterSecond, outcome) = afterFirst.makeGuess("Nope".asGuess())
+        whenever("maskedPrompt after one hit") {
+            val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
+            then("first token revealed, second hidden") {
+                val masked = afterHit.maskedPrompt()
+                masked.tokens[0] shouldBe MaskedToken.Revealed("hello")
+                masked.tokens[1] shouldBe MaskedToken.Hidden(5)
+            }
+        }
 
-        // Then
-        assertEquals(GuessOutcome.DUPLICATE, outcome)
-        assertEquals(2, afterSecond.lives.remaining)
+        whenever("maxLives is queried") {
+            then("derives from secret and difficulty") {
+                mediumChallenge().maxLives() shouldBe Lives(6)
+            }
+        }
+
+        whenever("withPicture is called") {
+            val challenge = mediumChallenge()
+            val newPicture = readyPicture("https://example.com/img.png")
+            val updated = challenge.withPicture(newPicture)
+            then("picture updated, version same, original untouched, not same reference") {
+                updated.picture shouldBe newPicture
+                updated.version shouldBe challenge.version
+                challenge.picture shouldBe Picture.Pending
+                (challenge !== updated).shouldBeTrue()
+            }
+        }
     }
 
-    @Test
-    fun `makeGuess does not mutate the receiver`() {
-        // Given
-        val challenge = mediumChallenge(lives = 3.lives())
-        val guess = "nope".asGuess()
-
-        // When
-        challenge.makeGuess(guess)
-
-        // Then
-        assertEquals(3, challenge.lives.remaining)
-        assertTrue(challenge.guesses.isEmpty())
+    given("Challenge.start") {
+        whenever("called with a prompt and lives") {
+            val challenge = Challenge.start("hello world".asPrompt(), 6.lives())
+            then("defaults to pending picture and medium difficulty in progress") {
+                challenge.picture shouldBe Picture.Pending
+                challenge.difficulty shouldBe Difficulty.MEDIUM
+                challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+            }
+        }
     }
 
-    @Test
-    fun `guessing after the challenge is over is rejected`() {
-        // Given
-        val (lost, _) = mediumChallenge(lives = 1.lives()).makeGuess("nope".asGuess())
-
-        // When / Then
-        assertFailsWith<ChallengeAlreadyOver> { lost.makeGuess("hello".asGuess()) }
-    }
-
-    @Test
-    fun `forfeit reveals the prompt and loses`() {
-        // Given
-        val challenge = mediumChallenge()
-
-        // When
-        val forfeited = challenge.forfeit()
-
-        // Then
-        assertEquals(ChallengeStatus.LOST, forfeited.status)
-        assertTrue(forfeited.maskedPrompt().tokens.all { it is MaskedToken.Revealed })
-    }
-
-    @Test
-    fun `forfeit after the challenge is over is rejected`() {
-        // Given
-        val forfeited = mediumChallenge().forfeit()
-
-        // When / Then
-        assertFailsWith<ChallengeAlreadyOver> { forfeited.forfeit() }
-    }
-
-    @Test
-    fun `withPicture returns an independent copy at the same version`() {
-        // Given
-        val challenge = mediumChallenge()
-        val newPicture = readyPicture("https://example.com/img.png")
-
-        // When
-        val updated = challenge.withPicture(newPicture)
-
-        // Then
-        assertEquals(newPicture, updated.picture)
-        assertEquals(challenge.version, updated.version)
-        assertEquals(Picture.Pending, challenge.picture)
-        assertNotSame(challenge, updated)
-    }
-
-    @Test
-    fun `maxLives derives from the challenge secret and difficulty`() {
-        // Given
-        val challenge = mediumChallenge()
-
-        // When
-        val max = challenge.maxLives()
-
-        // Then
-        assertEquals(Lives(6), max)
-    }
-
-    @Test
-    fun `maskedPrompt hides unguessed words while still in progress`() {
-        // Given
-        val (afterHit, _) = mediumChallenge().makeGuess("hello".asGuess())
-
-        // When
-        val masked = afterHit.maskedPrompt()
-
-        // Then
-        assertEquals(MaskedToken.Revealed("hello"), masked.tokens[0])
-        assertEquals(MaskedToken.Hidden(5), masked.tokens[1])
-    }
-
-    @Test
-    fun `start defaults to a pending picture and medium difficulty`() {
-        // Given
-        val prompt = "hello world".asPrompt()
-        val lives = 6.lives()
-
-        // When
-        val challenge = Challenge.start(prompt, lives)
-
-        // Then
-        assertEquals(Picture.Pending, challenge.picture)
-        assertEquals(Difficulty.MEDIUM, challenge.difficulty)
-        assertEquals(ChallengeStatus.IN_PROGRESS, challenge.status)
-    }
-
-    @Test
-    fun `rehydrate reconstitutes a challenge and preserves the secret prompt`() {
-        // Given
-        val prompt = "secret phrase".asPrompt()
-
-        // When
-        val challenge =
-            Challenge.rehydrate(
-                id = aChallengeId(),
-                prompt = prompt,
-                guesses = emptySet(),
-                lives = 4.lives(),
-                status = ChallengeStatus.IN_PROGRESS,
-                picture = Picture.Failed,
-                difficulty = Difficulty.HARD,
-                version = 7L,
-            )
-
-        // Then
-        assertEquals(prompt, challenge.secretPrompt())
-        assertEquals(4, challenge.lives.remaining)
-        assertEquals(ChallengeStatus.IN_PROGRESS, challenge.status)
-        assertEquals(Picture.Failed, challenge.picture)
-        assertEquals(Difficulty.HARD, challenge.difficulty)
-        assertEquals(7L, challenge.version)
+    given("Challenge.rehydrate") {
+        whenever("called with full state") {
+            val prompt = "secret phrase".asPrompt()
+            val challenge =
+                Challenge.rehydrate(
+                    id = aChallengeId(),
+                    prompt = prompt,
+                    guesses = emptySet(),
+                    lives = 4.lives(),
+                    status = ChallengeStatus.IN_PROGRESS,
+                    picture = Picture.Failed,
+                    difficulty = Difficulty.HARD,
+                    version = 7L,
+                )
+            then("reconstitutes the challenge and preserves all fields") {
+                challenge.secretPrompt() shouldBe prompt
+                challenge.lives.remaining shouldBe 4
+                challenge.status shouldBe ChallengeStatus.IN_PROGRESS
+                challenge.picture shouldBe Picture.Failed
+                challenge.difficulty shouldBe Difficulty.HARD
+                challenge.version shouldBe 7L
+            }
+        }
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/GuessTest.kt
@@ -1,38 +1,32 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
 import com.yonatankarp.beatthemachine.domain.exception.InvalidGuess
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class GuessTest {
-    @Test
-    fun `rejects blank word`() {
-        // Given
-        val word = "   "
-
-        // When / Then
-        assertFailsWith<InvalidGuess> { Guess(word) }
+val GuessSuite by testSuite {
+    given("constructing a Guess") {
+        whenever("the word is blank") {
+            then("it is rejected") {
+                shouldThrow<InvalidGuess> { Guess("   ") }
+            }
+        }
+        whenever("the word is empty") {
+            then("it is rejected") {
+                shouldThrow<InvalidGuess> { Guess("") }
+            }
+        }
     }
 
-    @Test
-    fun `rejects empty word`() {
-        // Given
-        val word = ""
-
-        // When / Then
-        assertFailsWith<InvalidGuess> { Guess(word) }
-    }
-
-    @Test
-    fun `normalized trims and lowercases`() {
-        // Given
-        val guess = Guess("Hello")
-
-        // When
-        val normalized = guess.normalized()
-
-        // Then
-        assertEquals("hello", normalized)
+    given("a Guess with mixed case") {
+        whenever("normalized") {
+            then("trims and lowercases") {
+                Guess("Hello").normalized() shouldBe "hello"
+            }
+        }
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/LivesTest.kt
@@ -1,77 +1,73 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class LivesTest {
-    @Test
-    fun `cannot be negative`() {
-        // Given
-        val count = -1
-
-        // When / Then
-        assertFailsWith<IllegalArgumentException> { Lives(count) }
+val LivesSuite by testSuite {
+    given("constructing Lives") {
+        whenever("count is negative") {
+            then("it is rejected") {
+                shouldThrow<IllegalArgumentException> { Lives(-1) }
+            }
+        }
     }
 
-    @Test
-    fun `lose decrements and floors at zero`() {
-        // Given
-        val oneLife = Lives(1)
-        val noLives = Lives(0)
-
-        // When
-        val afterLosingFromOne = oneLife.lose()
-        val afterLosingFromZero = noLives.lose()
-
-        // Then
-        assertEquals(Lives(0), afterLosingFromOne)
-        assertEquals(Lives(0), afterLosingFromZero)
+    given("Lives with one remaining") {
+        whenever("losing") {
+            then("decrements to zero") {
+                Lives(1).lose() shouldBe Lives(0)
+            }
+        }
     }
 
-    @Test
-    fun `is exhausted at zero`() {
-        // Given
-        val noLives = Lives(0)
-        val oneLife = Lives(1)
-
-        // When
-        val exhausted = noLives.isExhausted()
-        val notExhausted = oneLife.isExhausted()
-
-        // Then
-        assertTrue(exhausted)
-        assertFalse(notExhausted)
+    given("Lives at zero") {
+        whenever("losing") {
+            then("floors at zero") {
+                Lives(0).lose() shouldBe Lives(0)
+            }
+        }
     }
 
-    @Test
-    fun `forSecret scales lives by word count and difficulty`() {
-        // Given
+    given("Lives count") {
+        whenever("checking isExhausted") {
+            then("returns true at zero") {
+                Lives(0).isExhausted().shouldBeTrue()
+            }
+            then("returns false above zero") {
+                Lives(1).isExhausted().shouldBeFalse()
+            }
+        }
+    }
+
+    given("scaling lives with forSecret") {
         val twoWordPrompt = "hello world".asPrompt()
 
-        // When
-        val easy = Lives.forSecret(twoWordPrompt, Difficulty.EASY)
-        val medium = Lives.forSecret(twoWordPrompt, Difficulty.MEDIUM)
-        val hard = Lives.forSecret(twoWordPrompt, Difficulty.HARD)
-
-        // Then
-        assertEquals(Lives(9), easy)
-        assertEquals(Lives(6), medium)
-        assertEquals(Lives(4), hard)
-    }
-
-    @Test
-    fun `forSecret floors at MIN_LIVES for very short secrets`() {
-        // Given
-        val oneWordPrompt = "x".asPrompt()
-
-        // When
-        val result = Lives.forSecret(oneWordPrompt, Difficulty.HARD)
-
-        // Then
-        assertEquals(Lives(2), result) // round(3 * 1 * 0.7) = 2 >= MIN_LIVES
+        whenever("difficulty is EASY") {
+            then("scales up") {
+                Lives.forSecret(twoWordPrompt, Difficulty.EASY) shouldBe Lives(9)
+            }
+        }
+        whenever("difficulty is MEDIUM") {
+            then("scales moderately") {
+                Lives.forSecret(twoWordPrompt, Difficulty.MEDIUM) shouldBe Lives(6)
+            }
+        }
+        whenever("difficulty is HARD") {
+            then("scales down") {
+                Lives.forSecret(twoWordPrompt, Difficulty.HARD) shouldBe Lives(4)
+            }
+        }
+        whenever("a very short secret would produce fewer than MIN_LIVES") {
+            then("floors at MIN_LIVES") {
+                Lives.forSecret("x".asPrompt(), Difficulty.HARD) shouldBe Lives(2)
+            }
+        }
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
@@ -2,80 +2,69 @@ package com.yonatankarp.beatthemachine.domain.valueobject
 
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 
-class MaskedPromptTest {
-    @Test
-    fun `hides every word when there are no guesses`() {
-        // Given
-        val secret = "hello world".asPrompt()
-        val guesses = emptySet<Guess>()
-
-        // When
-        val masked = MaskedPrompt.of(secret, guesses)
-
-        // Then
-        assertEquals(listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5)), masked.tokens)
-        assertFalse(masked.isFullyRevealed())
+val MaskedPromptSuite by testSuite {
+    given("a two-word prompt with no guesses") {
+        whenever("masking") {
+            then("all tokens are hidden and not fully revealed") {
+                val masked = MaskedPrompt.of("hello world".asPrompt(), emptySet())
+                masked.tokens shouldBe listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5))
+                masked.isFullyRevealed().shouldBeFalse()
+            }
+        }
     }
 
-    @Test
-    fun `reveals a matching word case-insensitively`() {
-        // Given
-        val secret = "Hello World".asPrompt()
-        val guesses = setOf("hello".asGuess())
-
-        // When
-        val masked = MaskedPrompt.of(secret, guesses)
-
-        // Then
-        assertEquals(MaskedToken.Revealed("Hello"), masked.tokens[0])
-        assertEquals(MaskedToken.Hidden(5), masked.tokens[1])
+    given("a prompt with one word guessed") {
+        whenever("masking") {
+            then("first token is revealed and second is hidden") {
+                val masked = MaskedPrompt.of("Hello World".asPrompt(), setOf("hello".asGuess()))
+                masked.tokens[0] shouldBe MaskedToken.Revealed("Hello")
+                masked.tokens[1] shouldBe MaskedToken.Hidden(5)
+            }
+        }
     }
 
-    @Test
-    fun `reveals every occurrence of a repeated word`() {
-        // Given
-        val secret = "na na batman".asPrompt()
-        val guesses = setOf("na".asGuess())
-
-        // When
-        val masked = MaskedPrompt.of(secret, guesses)
-
-        // Then
-        assertEquals(
-            listOf(MaskedToken.Revealed("na"), MaskedToken.Revealed("na"), MaskedToken.Hidden(6)),
-            masked.tokens,
-        )
+    given("a prompt with a repeated word guessed") {
+        whenever("masking") {
+            then("both occurrences are revealed and batman is hidden") {
+                val masked = MaskedPrompt.of("na na batman".asPrompt(), setOf("na".asGuess()))
+                masked.tokens shouldBe
+                    listOf(
+                        MaskedToken.Revealed("na"),
+                        MaskedToken.Revealed("na"),
+                        MaskedToken.Hidden(6),
+                    )
+            }
+        }
     }
 
-    @Test
-    fun `collapses arbitrary whitespace using one rule`() {
-        // Given
-        val secret = "hello\t \nworld".asPrompt()
-        val guesses = setOf("world".asGuess())
-
-        // When
-        val masked = MaskedPrompt.of(secret, guesses)
-
-        // Then
-        assertEquals(2, masked.tokens.size)
-        assertEquals(MaskedToken.Revealed("world"), masked.tokens[1])
+    given("a prompt with mixed whitespace") {
+        whenever("masking with one word guessed") {
+            then("produces 2 tokens with the last revealed") {
+                val masked = MaskedPrompt.of("hello\t \nworld".asPrompt(), setOf("world".asGuess()))
+                masked.tokens.size shouldBe 2
+                masked.tokens[1] shouldBe MaskedToken.Revealed("world")
+            }
+        }
     }
 
-    @Test
-    fun `is fully revealed when all words are guessed`() {
-        // Given
-        val secret = "hello world".asPrompt()
-        val guesses = setOf("hello".asGuess(), "world".asGuess())
-
-        // When
-        val masked = MaskedPrompt.of(secret, guesses)
-
-        // Then
-        assertTrue(masked.isFullyRevealed())
+    given("all words guessed") {
+        whenever("masking") {
+            then("isFullyRevealed is true") {
+                val masked =
+                    MaskedPrompt.of(
+                        "hello world".asPrompt(),
+                        setOf("hello".asGuess(), "world".asGuess()),
+                    )
+                masked.isFullyRevealed().shouldBeTrue()
+            }
+        }
     }
 }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/MaskedPromptTest.kt
@@ -13,9 +13,12 @@ import io.kotest.matchers.shouldBe
 val MaskedPromptSuite by testSuite {
     given("a two-word prompt with no guesses") {
         whenever("masking") {
-            then("all tokens are hidden and not fully revealed") {
+            then("all tokens are hidden") {
                 val masked = MaskedPrompt.of("hello world".asPrompt(), emptySet())
                 masked.tokens shouldBe listOf(MaskedToken.Hidden(5), MaskedToken.Hidden(5))
+            }
+            then("the prompt is not fully revealed") {
+                val masked = MaskedPrompt.of("hello world".asPrompt(), emptySet())
                 masked.isFullyRevealed().shouldBeFalse()
             }
         }
@@ -23,9 +26,12 @@ val MaskedPromptSuite by testSuite {
 
     given("a prompt with one word guessed") {
         whenever("masking") {
-            then("first token is revealed and second is hidden") {
+            then("the first token is revealed") {
                 val masked = MaskedPrompt.of("Hello World".asPrompt(), setOf("hello".asGuess()))
                 masked.tokens[0] shouldBe MaskedToken.Revealed("Hello")
+            }
+            then("the second token is hidden") {
+                val masked = MaskedPrompt.of("Hello World".asPrompt(), setOf("hello".asGuess()))
                 masked.tokens[1] shouldBe MaskedToken.Hidden(5)
             }
         }
@@ -47,9 +53,12 @@ val MaskedPromptSuite by testSuite {
 
     given("a prompt with mixed whitespace") {
         whenever("masking with one word guessed") {
-            then("produces 2 tokens with the last revealed") {
+            then("produces exactly 2 tokens") {
                 val masked = MaskedPrompt.of("hello\t \nworld".asPrompt(), setOf("world".asGuess()))
                 masked.tokens.size shouldBe 2
+            }
+            then("the last token is revealed") {
+                val masked = MaskedPrompt.of("hello\t \nworld".asPrompt(), setOf("world".asGuess()))
                 masked.tokens[1] shouldBe MaskedToken.Revealed("world")
             }
         }

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/valueobject/PromptTest.kt
@@ -1,49 +1,32 @@
 package com.yonatankarp.beatthemachine.domain.valueobject
 
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import com.yonatankarp.beatthemachine.test.dsl.given
+import com.yonatankarp.beatthemachine.test.dsl.then
+import com.yonatankarp.beatthemachine.test.dsl.whenever
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
-class PromptTest {
-    @Test
-    fun `splits on single space`() {
-        // Given
-        val prompt = Prompt("hello world")
-
-        // When
-        val words = prompt.words()
-
-        // Then
-        assertEquals(listOf("hello", "world"), words)
+val PromptSuite by testSuite {
+    given("splitting a prompt into words") {
+        whenever("the text is separated by a single space") {
+            then("it splits into the words") {
+                Prompt("hello world").words() shouldBe listOf("hello", "world")
+            }
+        }
+        whenever("the text uses mixed whitespace") {
+            then("it still splits into the words") {
+                Prompt("a\t b\n c").words() shouldBe listOf("a", "b", "c")
+            }
+        }
     }
 
-    @Test
-    fun `splits on multiple whitespace characters`() {
-        // Given
-        val prompt = Prompt("a\t b\n c")
-
-        // When
-        val words = prompt.words()
-
-        // Then
-        assertEquals(listOf("a", "b", "c"), words)
-    }
-
-    @Test
-    fun `rejects blank text`() {
-        // Given
-        val text = "   "
-
-        // When / Then
-        assertFailsWith<IllegalArgumentException> { Prompt(text) }
-    }
-
-    @Test
-    fun `rejects empty text`() {
-        // Given
-        val text = ""
-
-        // When / Then
-        assertFailsWith<IllegalArgumentException> { Prompt(text) }
+    given("constructing a Prompt") {
+        whenever("the text is blank") {
+            then("it is rejected") { shouldThrow<IllegalArgumentException> { Prompt("   ") } }
+        }
+        whenever("the text is empty") {
+            then("it is rejected") { shouldThrow<IllegalArgumentException> { Prompt("") } }
+        }
     }
 }

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/dsl/GivenWhenThen.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/dsl/GivenWhenThen.kt
@@ -1,0 +1,19 @@
+package com.yonatankarp.beatthemachine.test.dsl
+
+import de.infix.testBalloon.framework.core.Test
+import de.infix.testBalloon.framework.core.TestSuiteScope
+
+fun TestSuiteScope.given(
+    description: String,
+    content: TestSuiteScope.() -> Unit,
+): Unit = testSuite("given $description") { content() }
+
+fun TestSuiteScope.whenever(
+    description: String,
+    content: TestSuiteScope.() -> Unit,
+): Unit = testSuite("when $description") { content() }
+
+fun TestSuiteScope.then(
+    description: String,
+    action: suspend Test.ExecutionScope.() -> Unit,
+): Unit = test("then $description") { action() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,12 @@ plugins {
 subprojects {
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/yonatankarp/testballoon-spring")
+            credentials {
+                username = (findProperty("gpr.user") as String?) ?: System.getenv("GITHUB_ACTOR")
+                password = (findProperty("gpr.key") as String?) ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+
+# testBalloon: nested IntelliJ test tree without the fully-qualified suite class prefix
+testBalloon.reportingMode=GradleIntellijIdeaWithNesting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
 openapiContracts = "0.1.0"
 mockk = "1.14.11"
-springmockk = "5.0.1"
 jvm = "25"
 # Matches the version managed by Spring Boot 4.1.0's BOM (kotlinx-coroutines-bom).
 # Pinned here for the application module, which has no Spring dependency management.
@@ -24,7 +23,6 @@ spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-s
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-starter-jdbc" }
-spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-boot-starter-webflux-test = { module = "org.springframework.boot:spring-boot-starter-webflux-test" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
@@ -33,12 +31,10 @@ kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
 
 # --- Explicitly versioned (not on the BOM, or used where the BOM is absent) ---
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
-springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmockk" }
 spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai" }
 spring-ai-starter-model-openai = { module = "org.springframework.ai:spring-ai-starter-model-openai" }
 spring-ai-starter-model-ollama = { module = "org.springframework.ai:spring-ai-starter-model-ollama" }
@@ -64,16 +60,13 @@ kotlinx-coroutines = [
 unit-test = [
     "testballoon-core",
     "kotest-assertions-core",
-    "kotlin-test",
     "mockk",
     "mockwebserver",
 ]
-# Spring slice/integration testing plus the springmockk @MockkBean bridge.
+# Spring slice/integration testing.
 spring-boot-test = [
     "testballoon-spring",
-    "spring-boot-starter-test",
     "spring-boot-starter-webflux-test",
-    "springmockk",
 ]
 # Spring AI model starters (versions resolved by the spring-ai-bom platform).
 spring-ai-starters = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,9 @@ jvm = "25"
 kotlinx-coroutines = "1.11.0"
 mockwebserver = "4.12.0"
 spring-ai = "2.0.0"
+testballoon = "1.0.1-K2.4.0"
+kotest = "6.0.3"
+junit-platform-launcher = "6.0.3"
 
 [libraries]
 # --- Versions managed by Spring Boot's BOM (no version declared here) ---
@@ -39,6 +42,10 @@ springmockk = { module = "com.ninja-squad:springmockk", version.ref = "springmoc
 spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai" }
 spring-ai-starter-model-openai = { module = "org.springframework.ai:spring-ai-starter-model-openai" }
 spring-ai-starter-model-ollama = { module = "org.springframework.ai:spring-ai-starter-model-ollama" }
+testballoon-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
+testballoon-spring = { module = "com.yonatankarp:testballoon-spring", version = "0.1.1" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform-launcher" }
 
 [bundles]
 # Production Spring Boot starters used by the adapters module.
@@ -55,12 +62,15 @@ kotlinx-coroutines = [
 ]
 # Plain unit-testing stack shared by every module.
 unit-test = [
+    "testballoon-core",
+    "kotest-assertions-core",
     "kotlin-test",
     "mockk",
     "mockwebserver",
 ]
 # Spring slice/integration testing plus the springmockk @MockkBean bridge.
 spring-boot-test = [
+    "testballoon-spring",
     "spring-boot-starter-test",
     "spring-boot-starter-webflux-test",
     "springmockk",
@@ -79,3 +89,4 @@ spring-dependency-management = { id = "io.spring.dependency-management", version
 openapi-contracts = { id = "com.yonatankarp.openapi.contracts", version.ref = "openapiContracts" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle" }
 openapi-generator = { id = "org.openapi.generator", version.ref = "openapi-generator" }
+testballoon = { id = "de.infix.testBalloon", version.ref = "testballoon" }


### PR DESCRIPTION
Migrates all test files across the three modules from JUnit5 + kotlin.test +
MockK + springmockk to [testBalloon](https://github.com/infix-de/testBalloon)
suites, using [testballoon-spring](https://github.com/yonatankarp/testballoon-spring)
`0.1.1` for the Spring tests and Kotest assertions throughout. Adds a
`given/whenever/then` DSL and adopts it across the domain suites.

(Supersedes #32, which was based on a stale `main`; this is a clean run on
current `main` and covers the pre-seed-pool / Picture / Spring AI / config tests
that landed since.)

## What changed
- **Framework:** every `class XTest { @Test }` becomes a top-level `val XSuite by testSuite { ... }`.
- **given/whenever/then DSL** (domain `testFixtures`): `given`/`whenever` are nested
  `testSuite`s, `then` is a `test` leaf; nesting gives closure scoping, so scenarios
  read as Given/When/Then with plain `val`s and no threading. All 5 domain suites use it.
- **Spring tests:** `@WebFluxTest`/`@SpringBootTest` use a carrier `class FooContext : SpringTestConfig()`
  + `springTest<FooContext>`, with value-based `mockBean<T>()` replacing springmockk
  `@MockkBean` and `bean<WebTestClient>()` replacing constructor injection. Config tests
  (ApplicationContextRunner) and the SQLite ITs stay flat `test {}`.
- **Assertions:** kotlin.test -> Kotest (`shouldBe`, `shouldThrow`, ...).
- **Build:** testBalloon Gradle plugin on all three modules, `org.junit.platform`
  forced to `6.0.3` (Spring Boot 4.1 ships JUnit Jupiter 6, which needs platform 6.x;
  testBalloon also runs on 6.0.3), `extra["kotlin.version"]` on adapters, GitHub Packages
  repo for `testballoon-spring`. `kotlin-test`/`springmockk`/`spring-boot-starter-test`
  removed; `mockwebserver` kept (used by the Spring AI / local-SD tests).

## Invariants held
- **Zero production (`src/main`) changes** — behaviour-preserving test migration.
- **Fresh-fixture rule:** mutable fixtures (stores, mocks, SQLite DBs) constructed per
  test; `MockWebServer` lifecycle via `TestConfig.aroundAll`; fresh in-memory DB per IT.
- **Coverage gates green:** domain 100% line/branch; application 94/100; adapters 92/82
  (gates 80/70). `./gradlew clean check` green from clean: **129 tests** (domain 35,
  application 20, adapters 74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated existing test coverage across modules to a suite-based testing approach with consistent assertions and clearer scenario structuring, including WebFlux/Spring context tests, controller behavior checks, and domain/unit validations.
  * Updated and standardized test utilities with a small given/when/then DSL to improve fixture-style test readability.

* **Chores**
  * Adopted the TestBalloon Gradle plugin across modules, aligned test dependencies (including the JUnit platform launcher), and centralized version control for launcher artifacts.
  * Extended build repository configuration for TestBalloon artifacts and improved nested test reporting layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->