### PR TITLE
[codex] Fix review findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,15 @@ updates:
       - "type: dependencies"
       - "relates-to: build"
 
+  # Maintain dependencies for the React frontend
+  - package-ecosystem: "npm"
+    directory: "/beat-the-machine-frontend"
+    schedule:
+      interval: "daily"
+    labels:
+      - "type: dependencies"
+      - "relates-to: frontend"
+      - "relates-to: build"
+
 # See https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-dependencies-updated-automatically
 # for more information about configuring Dependabot.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   pipeline:
     permissions:
       contents: read
+      packages: read
       pull-requests: write
       checks: write
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v2

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/ImageRendering.kt
@@ -3,8 +3,13 @@ package com.yonatankarp.beatthemachine.output.ai
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import io.netty.channel.ChannelOption
+import kotlinx.coroutines.CancellationException
 import org.slf4j.Logger
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
 
 internal const val MAX_IMAGE_BYTES = 16 * 1024 * 1024
 
@@ -12,12 +17,22 @@ internal const val PNG_CONTENT_TYPE = "image/png"
 
 internal const val IMAGE_PATH_PREFIX = "/images/"
 
+private val IMAGE_REQUEST_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+private const val IMAGE_CONNECT_TIMEOUT_MILLIS = 5000
+
 internal fun imageUrl(id: String): String = "$IMAGE_PATH_PREFIX$id"
 
 internal fun imageWebClient(baseUrl: String? = null): WebClient {
+    val httpClient =
+        HttpClient
+            .create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, IMAGE_CONNECT_TIMEOUT_MILLIS)
+            .responseTimeout(IMAGE_REQUEST_TIMEOUT)
     val builder = WebClient.builder()
     if (baseUrl != null) builder.baseUrl(baseUrl)
     return builder
+        .clientConnector(ReactorClientHttpConnector(httpClient))
         .codecs { it.defaultCodecs().maxInMemorySize(MAX_IMAGE_BYTES) }
         .build()
 }
@@ -30,6 +45,8 @@ internal suspend fun StorePicture.renderedPicture(
     try {
         val bytes = produce() ?: return Picture.Failed
         Picture.Ready(imageUrl(this handle StorePicture.Command(bytes, PNG_CONTENT_TYPE)))
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         logger.warn("Image generation failed for prompt '{}'", prompt.text, e)
         Picture.Failed

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachine.kt
@@ -9,14 +9,18 @@ import org.slf4j.LoggerFactory
 import org.springframework.ai.image.Image
 import org.springframework.ai.image.ImageModel
 import org.springframework.ai.image.ImagePrompt
+import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.awaitEntity
+import java.net.InetAddress
+import java.net.URI
 import java.util.Base64
 
 class SpringAiImageMachine(
     private val imageModel: ImageModel,
     private val storePicture: StorePicture,
     private val webClient: WebClient = imageWebClient(),
+    private val imageUrlPolicy: ImageUrlPolicy = ImageUrlPolicy.Default,
 ) : Machine {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -27,22 +31,52 @@ class SpringAiImageMachine(
             }?.resolvedBytes()
         }
 
-    private suspend fun Image.resolvedBytes(): ByteArray? =
-        when {
-            !b64Json.isNullOrBlank() -> {
-                Base64.getDecoder().decode(b64Json)
-            }
-
-            !url.isNullOrBlank() -> {
-                webClient
-                    .get()
-                    .uri(url!!)
-                    .retrieve()
-                    .awaitBody<ByteArray>()
-            }
-
-            else -> {
-                null
-            }
+    private suspend fun Image.resolvedBytes(): ByteArray? {
+        val encodedImage = b64Json
+        if (!encodedImage.isNullOrBlank()) {
+            return Base64.getDecoder().decode(encodedImage)
         }
+
+        val imageUrl = url
+        if (imageUrl.isNullOrBlank()) return null
+
+        val uri = URI.create(imageUrl)
+        if (!imageUrlPolicy.allows(uri)) return null
+
+        val response =
+            webClient
+                .get()
+                .uri(uri)
+                .retrieve()
+                .awaitEntity<ByteArray>()
+        if (response.headers.contentType?.isImage() != true) return null
+        return response.body
+    }
 }
+
+fun interface ImageUrlPolicy {
+    fun allows(uri: URI): Boolean
+
+    object Default : ImageUrlPolicy {
+        override fun allows(uri: URI): Boolean {
+            if (uri.scheme != "https") return false
+            val host = uri.host ?: return false
+            return runCatching {
+                InetAddress.getAllByName(host).none { it.isPrivateNetworkAddress() }
+            }.getOrDefault(false)
+        }
+    }
+
+    object AllowAll : ImageUrlPolicy {
+        override fun allows(uri: URI): Boolean = true
+    }
+}
+
+private fun InetAddress.isPrivateNetworkAddress(): Boolean =
+    isAnyLocalAddress ||
+        isLoopbackAddress ||
+        isLinkLocalAddress ||
+        isSiteLocalAddress ||
+        isMulticastAddress
+
+private fun MediaType.isImage(): Boolean = type.equals("image", ignoreCase = true)

--- a/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRowMapper.kt
+++ b/beat-the-machine-adapters/src/main/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/ChallengeRowMapper.kt
@@ -9,7 +9,13 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
 import org.springframework.jdbc.core.RowMapper
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 import java.util.UUID
+
+private const val GUESS_DELIMITER = "|"
+private val guessEncoder = Base64.getUrlEncoder().withoutPadding()
+private val guessDecoder = Base64.getUrlDecoder()
 
 class ChallengeRowMapper {
     val rowMapper: RowMapper<ChallengeRow> =
@@ -40,7 +46,7 @@ class ChallengeRowMapper {
         return ChallengeRow(
             id = challenge.id.value.toString(),
             prompt = challenge.secretPrompt().text,
-            guesses = challenge.guesses.joinToString(GUESS_DELIMITER) { it.word },
+            guesses = challenge.guesses.joinToString(GUESS_DELIMITER) { it.word.encodeGuess() },
             lives = challenge.lives.remaining,
             status = challenge.status.name,
             pictureStatus = pictureStatus,
@@ -55,16 +61,14 @@ class ChallengeRowMapper {
             when (row.pictureStatus) {
                 "READY" -> Picture.Ready(row.pictureUrl ?: throw IllegalStateException("READY picture row ${row.id} has null url"))
                 "FAILED" -> Picture.Failed
-                else -> Picture.Pending
+                "PENDING" -> Picture.Pending
+                else -> throw IllegalStateException("Unknown picture_status ${row.pictureStatus} for challenge ${row.id}")
             }
         val guesses =
             if (row.guesses.isBlank()) {
                 emptySet()
             } else {
-                row.guesses
-                    .split(GUESS_DELIMITER)
-                    .map { Guess(it) }
-                    .toSet()
+                row.guesses.decodeGuesses()
             }
         return Challenge.rehydrate(
             id = ChallengeId(UUID.fromString(row.id)),
@@ -77,8 +81,13 @@ class ChallengeRowMapper {
             version = row.version,
         )
     }
-
-    private companion object {
-        const val GUESS_DELIMITER = "|"
-    }
 }
+
+private fun String.encodeGuess(): String = guessEncoder.encodeToString(toByteArray(StandardCharsets.UTF_8))
+
+private fun String.decodeGuesses(): Set<Guess> =
+    split(GUESS_DELIMITER)
+        .map { it.decodeGuess() }
+        .toSet()
+
+private fun String.decodeGuess(): Guess = Guess(String(guessDecoder.decode(this), StandardCharsets.UTF_8))

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/ai/SpringAiImageMachineTest.kt
@@ -4,16 +4,20 @@ import com.yonatankarp.beatthemachine.application.port.output.Machine
 import com.yonatankarp.beatthemachine.application.port.output.StorePicture
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.springframework.ai.image.Image
@@ -44,16 +48,74 @@ val SpringAiImageMachineSuite by testSuite {
                 val server = MockWebServer()
                 server.start()
                 val pngBytes = "PNGDATA".toByteArray()
-                server.enqueue(MockResponse().setBody("PNGDATA"))
+                server.enqueue(MockResponse().setHeader("Content-Type", "image/png").setBody("PNGDATA"))
                 every { imageModel.call(any()) } returns
                     ImageResponse(listOf(ImageGeneration(Image(server.url("/img.png").toString(), null))))
                 val saved = slot<StorePicture.Command>()
                 coEvery { storePicture handle capture(saved) } returns "paid2"
-                val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient())
+                val machine = SpringAiImageMachine(imageModel, storePicture, imageWebClient(), ImageUrlPolicy.AllowAll)
                 val result = machine answer Machine.Query(Prompt("astronaut eating the moon"))
                 result shouldBe Picture.Ready("/images/paid2")
                 pngBytes.contentEquals(saved.captured.bytes).shouldBeTrue()
                 server.shutdown()
+            }
+        }
+
+        given("the model returns an unsafe url") {
+            val server by setup {
+                MockWebServer().apply { start() }
+            }
+            val storePicture by setup { mockk<StorePicture>() }
+            val imageModel by setup {
+                mockk<ImageModel>().also {
+                    every { it.call(any()) } returns
+                        ImageResponse(listOf(ImageGeneration(Image(server.url("/private.png").toString(), null))))
+                }
+            }
+            val machine by setup {
+                SpringAiImageMachine(imageModel, storePicture, imageWebClient())
+            }
+
+            whenever("answering the prompt") {
+                val result by action {
+                    machine answer Machine.Query(Prompt("astronaut eating the moon"))
+                }
+
+                then("it rejects the url without fetching it") {
+                    result shouldBe Picture.Failed
+                    server.requestCount shouldBe 0
+                    server.shutdown()
+                }
+            }
+        }
+
+        given("the model url returns a non-image content type") {
+            val server by setup {
+                MockWebServer().apply {
+                    start()
+                    enqueue(MockResponse().setHeader("Content-Type", "text/plain").setBody("not image"))
+                }
+            }
+            val storePicture by setup { mockk<StorePicture>() }
+            val imageModel by setup {
+                mockk<ImageModel>().also {
+                    every { it.call(any()) } returns
+                        ImageResponse(listOf(ImageGeneration(Image(server.url("/img.txt").toString(), null))))
+                }
+            }
+            val machine by setup {
+                SpringAiImageMachine(imageModel, storePicture, imageWebClient(), ImageUrlPolicy.AllowAll)
+            }
+
+            whenever("answering the prompt") {
+                val result by action {
+                    machine answer Machine.Query(Prompt("astronaut eating the moon"))
+                }
+
+                then("it rejects the response") {
+                    result shouldBe Picture.Failed
+                    server.shutdown()
+                }
             }
         }
 
@@ -64,6 +126,18 @@ val SpringAiImageMachineSuite by testSuite {
                 every { imageModel.call(any()) } throws RuntimeException("boom")
                 val machine = SpringAiImageMachine(imageModel, storePicture)
                 machine answer Machine.Query(Prompt("anything")) shouldBe Picture.Failed
+            }
+        }
+
+        whenever("the image work is cancelled") {
+            then("it propagates cancellation") {
+                val storePicture = mockk<StorePicture>()
+                val imageModel = mockk<ImageModel>()
+                every { imageModel.call(any()) } throws CancellationException("stopping")
+                val machine = SpringAiImageMachine(imageModel, storePicture)
+                shouldThrow<CancellationException> {
+                    machine answer Machine.Query(Prompt("anything"))
+                }
             }
         }
     }

--- a/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
+++ b/beat-the-machine-adapters/src/test/kotlin/com/yonatankarp/beatthemachine/output/persistence/sqlite/SqliteStoreChallengeIntegrationTest.kt
@@ -5,13 +5,17 @@ import com.yonatankarp.beatthemachine.application.port.output.FindChallengeById
 import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.dsl.lives
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallengeWithGuesses
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.failedPicture
 import com.yonatankarp.beatthemachine.test.fixtures.Pictures.readyPicture
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
@@ -21,66 +25,146 @@ import io.kotest.matchers.shouldBe
 
 val SqliteStoreChallengeITSuite by testSuite {
     given("a fresh challenge") {
+        val adapters by setup { newSqliteAdapters() }
+        val challenge by setup { mediumChallenge(prompt = "pixel art cat".asPrompt()) }
+
         whenever("storing it") {
+            val saved by action {
+                val (storeChallenge) = adapters
+                storeChallenge handle StoreChallenge.Command(challenge)
+            }
+
             then("it stores the challenge and bumps the version") {
-                val (storeChallenge) = newSqliteAdapters()
-                val challenge = mediumChallenge(prompt = "pixel art cat".asPrompt())
-                val saved = storeChallenge handle StoreChallenge.Command(challenge)
                 saved.version shouldBe 1L
             }
         }
     }
 
     given("a stored challenge") {
+        val adapters by setup { newSqliteAdapters() }
+        val challenge by setup { mediumChallenge(prompt = "sequential".asPrompt()) }
+        val stored by setup {
+            val (storeChallenge) = adapters
+            storeChallenge handle StoreChallenge.Command(challenge)
+        }
+
         whenever("storing it again sequentially") {
+            val restored by action {
+                val (storeChallenge) = adapters
+                storeChallenge handle StoreChallenge.Command(stored)
+            }
+
             then("it allows sequential stores with updated versions") {
-                val (storeChallenge) = newSqliteAdapters()
-                val challenge = mediumChallenge(prompt = "sequential".asPrompt())
-                val v1 = storeChallenge handle StoreChallenge.Command(challenge)
-                val v2 = storeChallenge handle StoreChallenge.Command(v1)
-                v1.version shouldBe 1L
-                v2.version shouldBe 2L
+                stored.version shouldBe 1L
+                restored.version shouldBe 2L
             }
         }
 
         whenever("storing a stale version on second store") {
+            val storedVersion by action { stored.version }
+            val result by action {
+                val (storeChallenge) = adapters
+                shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(challenge) }
+            }
+
             then("it rejects the stale version") {
-                val (storeChallenge) = newSqliteAdapters()
-                val c = mediumChallenge()
-                storeChallenge handle StoreChallenge.Command(c)
-                shouldThrow<OptimisticLockConflict> { storeChallenge handle StoreChallenge.Command(c) }
+                storedVersion shouldBe 1L
+                result.id shouldBe challenge.id
             }
         }
     }
 
     given("challenges of every difficulty level") {
+        val adapters by setup { newSqliteAdapters() }
+
         whenever("storing and reloading them") {
-            then("it persists all difficulty levels") {
-                val (storeChallenge, findChallengeById) = newSqliteAdapters()
-                Difficulty.entries.forEach { diff ->
+            val foundDifficulties by action {
+                val (storeChallenge, findChallengeById) = adapters
+                Difficulty.entries.map { diff ->
                     val c = Challenge.start("test prompt".asPrompt(), 2.lives(), difficulty = diff)
                     storeChallenge handle StoreChallenge.Command(c)
                     val found = findChallengeById answer FindChallengeById.Query(c.id)
                     found.shouldNotBeNull()
-                    found.difficulty shouldBe diff
+                    found.difficulty
                 }
+            }
+
+            then("it persists all difficulty levels") {
+                foundDifficulties shouldBe Difficulty.entries
             }
         }
     }
 
     given("challenges with pending, ready and failed pictures") {
+        val adapters by setup { newSqliteAdapters() }
+        val pending by setup { mediumChallenge(prompt = "pending pic".asPrompt()) }
+        val ready by setup { mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture()) }
+        val failed by setup { mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture()) }
+
         whenever("storing and reloading them") {
-            then("it persists picture states correctly") {
-                val (storeChallenge, findChallengeById) = newSqliteAdapters()
-                val pending = mediumChallenge(prompt = "pending pic".asPrompt())
-                val ready = mediumChallenge(prompt = "ready pic".asPrompt(), picture = readyPicture())
-                val failed = mediumChallenge(prompt = "failed pic".asPrompt(), picture = failedPicture())
+            val pictures by action {
+                val (storeChallenge, findChallengeById) = adapters
                 storeChallenge handle StoreChallenge.Command(pending)
                 storeChallenge handle StoreChallenge.Command(ready)
                 storeChallenge handle StoreChallenge.Command(failed)
-                (findChallengeById answer FindChallengeById.Query(pending.id))?.picture shouldBe Picture.Pending
-                (findChallengeById answer FindChallengeById.Query(ready.id))?.picture shouldBe Picture.Ready("https://example.com/img.png")
-                (findChallengeById answer FindChallengeById.Query(failed.id))?.picture shouldBe Picture.Failed
+                listOf(
+                    (findChallengeById answer FindChallengeById.Query(pending.id))?.picture,
+                    (findChallengeById answer FindChallengeById.Query(ready.id))?.picture,
+                    (findChallengeById answer FindChallengeById.Query(failed.id))?.picture,
+                )
+            }
+
+            then("it persists picture states correctly") {
+                pictures shouldBe
+                    listOf(
+                        Picture.Pending,
+                        Picture.Ready("https://example.com/img.png"),
+                        Picture.Failed,
+                    )
+            }
+        }
+    }
+
+    given("a challenge with a guess containing the old delimiter") {
+        val adapters by setup { newSqliteAdapters() }
+        val challenge by setup {
+            mediumChallengeWithGuesses(
+                prompt = "pipe guess".asPrompt(),
+                guesses = setOf(Guess("a|b")),
+                lives = 2.lives(),
+            )
+        }
+
+        whenever("storing and reloading it") {
+            val found by action {
+                val (storeChallenge, findChallengeById) = adapters
+                storeChallenge handle StoreChallenge.Command(challenge)
+                findChallengeById answer FindChallengeById.Query(challenge.id)
+            }
+
+            then("it preserves the guess as one value") {
+                val reloaded = found.shouldNotBeNull()
+                reloaded.guesses shouldBe setOf(Guess("a|b"))
+            }
+        }
+    }
+
+    given("a row with an unknown picture status") {
+        val adapters by setup { newSqliteAdapters() }
+        val challenge by setup { mediumChallenge(prompt = "bad status".asPrompt()) }
+
+        whenever("loading it") {
+            val result by action {
+                val (storeChallenge, findChallengeById, _, _, _, jdbc) = adapters
+                storeChallenge handle StoreChallenge.Command(challenge)
+                jdbc.update("UPDATE challenge SET picture_status = ? WHERE id = ?", "BROKEN", challenge.id.value.toString())
+                shouldThrow<IllegalStateException> {
+                    findChallengeById answer FindChallengeById.Query(challenge.id)
+                }
+            }
+
+            then("it fails instead of treating the row as pending") {
+                result.message shouldBe "Unknown picture_status BROKEN for challenge ${challenge.id.value}"
             }
         }
     }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/ForfeitChallengeUseCaseTest.kt
@@ -7,7 +7,9 @@ import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
@@ -16,27 +18,34 @@ import io.kotest.matchers.shouldBe
 
 val ForfeitChallengeUseSuite by testSuite {
     given("a stored challenge") {
+        val store by setup { FakeChallengeStore() }
+        val challenge by setup { store handle StoreChallenge.Command(mediumChallenge()) }
+        val forfeitChallenge by setup { ForfeitChallengeUseCase(store, store) }
+
         whenever("forfeiting it") {
+            val result by action { forfeitChallenge handle ForfeitChallenge.Command(challenge.id) }
+
             then("it sets the status to LOST and persists it") {
-                val store = FakeChallengeStore()
-                val c = store handle StoreChallenge.Command(mediumChallenge())
-                val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-                val result = forfeitChallenge handle ForfeitChallenge.Command(c.id)
                 result.status shouldBe ChallengeStatus.LOST
-                (store answer FindChallengeById.Query(c.id))?.status shouldBe ChallengeStatus.LOST
+                (store answer FindChallengeById.Query(challenge.id))?.status shouldBe ChallengeStatus.LOST
             }
         }
     }
 
     given("an unknown challenge") {
+        val store by setup { FakeChallengeStore() }
+        val forfeitChallenge by setup { ForfeitChallengeUseCase(store, store) }
+        val unknownId by setup { aChallengeId() }
+
         whenever("forfeiting it") {
-            then("it throws ChallengeNotFound") {
-                val store = FakeChallengeStore()
-                val forfeitChallenge = ForfeitChallengeUseCase(store, store)
-                val unknownId = aChallengeId()
+            val result by action {
                 shouldThrow<ChallengeNotFound> {
                     forfeitChallenge handle ForfeitChallenge.Command(unknownId)
                 }
+            }
+
+            then("it throws ChallengeNotFound") {
+                result.id shouldBe unknownId
             }
         }
     }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/GetChallengeUseCaseTest.kt
@@ -6,7 +6,9 @@ import com.yonatankarp.beatthemachine.application.port.output.StoreChallenge
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asPrompt
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
@@ -15,24 +17,31 @@ import io.kotest.matchers.shouldBe
 
 val GetChallengeSuite by testSuite {
     given("a stored challenge") {
+        val store by setup { FakeChallengeStore() }
+        val getChallenge by setup { GetChallengeUseCase(store) }
+        val challenge by setup { store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt())) }
+
         whenever("getting it by id") {
+            val result by action { getChallenge answer GetChallenge.Query(challenge.id) }
+
             then("it returns the challenge") {
-                val store = FakeChallengeStore()
-                val getChallenge = GetChallengeUseCase(store)
-                val challenge = store handle StoreChallenge.Command(mediumChallenge(prompt = "red fox".asPrompt()))
-                val result = getChallenge answer GetChallenge.Query(challenge.id)
                 result shouldBe challenge
             }
         }
     }
 
     given("an unknown id") {
+        val store by setup { FakeChallengeStore() }
+        val getChallenge by setup { GetChallengeUseCase(store) }
+        val unknownId by setup { aChallengeId() }
+
         whenever("getting the challenge") {
-            then("it throws ChallengeNotFound") {
-                val store = FakeChallengeStore()
-                val getChallenge = GetChallengeUseCase(store)
-                val unknownId = aChallengeId()
+            val result by action {
                 shouldThrow<ChallengeNotFound> { getChallenge answer GetChallenge.Query(unknownId) }
+            }
+
+            then("it throws ChallengeNotFound") {
+                result.id shouldBe unknownId
             }
         }
     }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/MakeGuessUseCaseTest.kt
@@ -11,7 +11,9 @@ import com.yonatankarp.beatthemachine.domain.valueobject.MaskedToken
 import com.yonatankarp.beatthemachine.test.dsl.aChallengeId
 import com.yonatankarp.beatthemachine.test.dsl.asGuess
 import com.yonatankarp.beatthemachine.test.fixtures.Challenges.mediumChallenge
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
@@ -20,49 +22,62 @@ import io.kotest.matchers.shouldBe
 
 val MakeGuessUseSuite by testSuite {
     given("a stored challenge") {
+        val store by setup { FakeChallengeStore() }
+        val challenge by setup { store handle StoreChallenge.Command(mediumChallenge()) }
+        val makeGuess by setup { MakeGuessUseCase(store, store) }
+        val guess by setup { "hello".asGuess() }
+
         whenever("a correct guess is made") {
+            val result by action { makeGuess handle MakeGuess.Command(challenge.id, guess) }
+
             then("the hit is returned and persisted") {
-                val store = FakeChallengeStore()
-                val c = store handle StoreChallenge.Command(mediumChallenge())
-                val makeGuess = MakeGuessUseCase(store, store)
-                val guess = "hello".asGuess()
-                val (updated, outcome) = makeGuess handle MakeGuess.Command(c.id, guess)
+                val (updated, outcome) = result
                 outcome shouldBe GuessOutcome.HIT
                 updated.maskedPrompt().tokens[0] shouldBe MaskedToken.Revealed("hello")
-                (store answer FindChallengeById.Query(c.id))?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
+                (store answer FindChallengeById.Query(challenge.id))?.maskedPrompt()?.tokens?.get(0) shouldBe MaskedToken.Revealed("hello")
             }
         }
     }
 
     given("an unknown challenge") {
+        val store by setup { FakeChallengeStore() }
+        val makeGuess by setup { MakeGuessUseCase(store, store) }
+        val unknownId by setup { aChallengeId() }
+        val guess by setup { "hello".asGuess() }
+
         whenever("a guess is made") {
-            then("it throws ChallengeNotFound") {
-                val store = FakeChallengeStore()
-                val makeGuess = MakeGuessUseCase(store, store)
-                val unknownId = aChallengeId()
-                val guess = "hello".asGuess()
+            val result by action {
                 shouldThrow<ChallengeNotFound> {
                     makeGuess handle MakeGuess.Command(unknownId, guess)
                 }
+            }
+
+            then("it throws ChallengeNotFound") {
+                result.id shouldBe unknownId
             }
         }
     }
 
     given("a store that conflicts on write") {
+        val store by setup { FakeChallengeStore() }
+        val challenge by setup { store handle StoreChallenge.Command(mediumChallenge()) }
+        val conflicting by setup {
+            object : StoreChallenge {
+                override suspend fun handle(command: StoreChallenge.Command): Challenge = throw OptimisticLockConflict(command.challenge.id)
+            }
+        }
+        val makeGuess by setup { MakeGuessUseCase(store, conflicting) }
+        val guess by setup { "hello".asGuess() }
+
         whenever("a guess is made") {
-            then("the optimistic-lock conflict propagates") {
-                val store = FakeChallengeStore()
-                val c = store handle StoreChallenge.Command(mediumChallenge())
-                val conflicting =
-                    object : StoreChallenge {
-                        override suspend fun handle(command: StoreChallenge.Command): Challenge =
-                            throw OptimisticLockConflict(command.challenge.id)
-                    }
-                val makeGuess = MakeGuessUseCase(store, conflicting)
-                val guess = "hello".asGuess()
+            val result by action {
                 shouldThrow<OptimisticLockConflict> {
-                    makeGuess handle MakeGuess.Command(c.id, guess)
+                    makeGuess handle MakeGuess.Command(challenge.id, guess)
                 }
+            }
+
+            then("the optimistic-lock conflict propagates") {
+                result.id shouldBe challenge.id
             }
         }
     }

--- a/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
+++ b/beat-the-machine-application/src/test/kotlin/com/yonatankarp/beatthemachine/application/usecase/StartChallengeUseCaseTest.kt
@@ -9,7 +9,9 @@ import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
+import com.yonatankarp.testballoon.gwt.action
 import com.yonatankarp.testballoon.gwt.given
+import com.yonatankarp.testballoon.gwt.setup
 import com.yonatankarp.testballoon.gwt.then
 import com.yonatankarp.testballoon.gwt.whenever
 import de.infix.testBalloon.framework.core.testSuite
@@ -21,20 +23,24 @@ import io.mockk.mockk
 
 val StartChallengeUseSuite by testSuite {
     given("a ready template in the pool") {
-        whenever("starting a challenge") {
-            then("it serves the template instantly without enqueuing a picture") {
-                val templates = mockk<ChallengeTemplates>()
-                val promptSource = mockk<PromptSource>()
-                val store = FakeChallengeStore()
-                val enqueued = mutableListOf<ChallengeId>()
-                val replenished = mutableListOf<Difficulty>()
-                coEvery { templates.randomReady(Difficulty.EASY) } returns
+        val templates by setup {
+            mockk<ChallengeTemplates>().also {
+                coEvery { it.randomReady(Difficulty.EASY) } returns
                     ChallengeTemplate("t1", Difficulty.EASY, Prompt("red car"), "/images/a")
-                val startChallenge =
-                    StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
+            }
+        }
+        val promptSource by setup { mockk<PromptSource>() }
+        val store by setup { FakeChallengeStore() }
+        val enqueued by setup { mutableListOf<ChallengeId>() }
+        val replenished by setup { mutableListOf<Difficulty>() }
+        val startChallenge by setup {
+            StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
+        }
 
-                val challenge = startChallenge handle StartChallenge.Command(Difficulty.EASY)
+        whenever("starting a challenge") {
+            val challenge by action { startChallenge handle StartChallenge.Command(Difficulty.EASY) }
 
+            then("it serves the template instantly without enqueuing a picture") {
                 challenge.picture shouldBe Picture.Ready("/images/a")
                 challenge.lives shouldBe Lives.forSecret(Prompt("red car"), Difficulty.EASY)
                 enqueued.shouldBeEmpty()
@@ -45,20 +51,27 @@ val StartChallengeUseSuite by testSuite {
     }
 
     given("an empty pool") {
+        val templates by setup {
+            mockk<ChallengeTemplates>().also {
+                coEvery { it.randomReady(Difficulty.HARD) } returns null
+            }
+        }
+        val promptSource by setup {
+            mockk<PromptSource>().also {
+                coEvery { it answer PromptSource.Query(Difficulty.HARD) } returns Prompt("a b c")
+            }
+        }
+        val store by setup { FakeChallengeStore() }
+        val enqueued by setup { mutableListOf<ChallengeId>() }
+        val replenished by setup { mutableListOf<Difficulty>() }
+        val startChallenge by setup {
+            StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
+        }
+
         whenever("starting a challenge") {
+            val challenge by action { startChallenge handle StartChallenge.Command(Difficulty.HARD) }
+
             then("it falls back to on-demand generation") {
-                val templates = mockk<ChallengeTemplates>()
-                val promptSource = mockk<PromptSource>()
-                val store = FakeChallengeStore()
-                val enqueued = mutableListOf<ChallengeId>()
-                val replenished = mutableListOf<Difficulty>()
-                coEvery { templates.randomReady(Difficulty.HARD) } returns null
-                coEvery { promptSource answer PromptSource.Query(Difficulty.HARD) } returns Prompt("a b c")
-                val startChallenge =
-                    StartChallengeUseCase(templates, promptSource, store, { enqueued += it }, { replenished += it })
-
-                val challenge = startChallenge handle StartChallenge.Command(Difficulty.HARD)
-
                 challenge.picture shouldBe Picture.Pending
                 enqueued shouldBe listOf(challenge.id)
                 replenished shouldBe listOf(Difficulty.HARD)

--- a/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
+++ b/beat-the-machine-domain/src/test/kotlin/com/yonatankarp/beatthemachine/domain/entity/ChallengeTest.kt
@@ -133,6 +133,7 @@ val ChallengeSuite by testSuite {
 
     given("a medium challenge") {
         val challenge by setup { mediumChallenge() }
+        val newPicture by setup { readyPicture("https://example.com/img.png") }
 
         whenever("forfeited") {
             val forfeited by action { challenge.forfeit() }
@@ -169,7 +170,6 @@ val ChallengeSuite by testSuite {
         }
 
         whenever("withPicture is called") {
-            val newPicture by setup { readyPicture("https://example.com/img.png") }
             val updated by action { challenge.withPicture(newPicture) }
 
             then("the picture is updated") {

--- a/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
+++ b/beat-the-machine-domain/src/testFixtures/kotlin/com/yonatankarp/beatthemachine/test/fixtures/Challenges.kt
@@ -1,7 +1,9 @@
 package com.yonatankarp.beatthemachine.test.fixtures
 
 import com.yonatankarp.beatthemachine.domain.entity.Challenge
+import com.yonatankarp.beatthemachine.domain.valueobject.ChallengeStatus
 import com.yonatankarp.beatthemachine.domain.valueobject.Difficulty
+import com.yonatankarp.beatthemachine.domain.valueobject.Guess
 import com.yonatankarp.beatthemachine.domain.valueobject.Lives
 import com.yonatankarp.beatthemachine.domain.valueobject.Picture
 import com.yonatankarp.beatthemachine.domain.valueobject.Prompt
@@ -20,6 +22,25 @@ object Challenges {
         lives: Lives = Lives.forSecret(prompt, Difficulty.MEDIUM),
         picture: Picture = Picture.Pending,
     ): Challenge = Challenge.start(prompt, lives, picture, Difficulty.MEDIUM)
+
+    fun mediumChallengeWithGuesses(
+        prompt: Prompt = "hello world".asPrompt(),
+        guesses: Set<Guess>,
+        lives: Lives = Lives.forSecret(prompt, Difficulty.MEDIUM),
+        status: ChallengeStatus = ChallengeStatus.IN_PROGRESS,
+        picture: Picture = Picture.Pending,
+        version: Long = 0,
+    ): Challenge =
+        Challenge.rehydrate(
+            id = mediumChallenge().id,
+            prompt = prompt,
+            guesses = guesses,
+            lives = lives,
+            status = status,
+            picture = picture,
+            difficulty = Difficulty.MEDIUM,
+            version = version,
+        )
 
     fun hardChallenge(
         prompt: Prompt = "hello world".asPrompt(),

--- a/beat-the-machine-frontend/build.gradle.kts
+++ b/beat-the-machine-frontend/build.gradle.kts
@@ -1,4 +1,7 @@
+import com.github.gradle.node.npm.task.NpmTask
+
 plugins {
+    base
     alias(libs.plugins.node.gradle)
     alias(libs.plugins.openapi.generator)
 }
@@ -35,11 +38,25 @@ openApiGenerate {
 
 tasks.named("npmInstall") { dependsOn(tasks.named("openApiGenerate")) }
 
-val buildWebApp by tasks.registering(com.github.gradle.node.npm.task.NpmTask::class) {
+val buildWebApp = tasks.register<NpmTask>("buildWebApp") {
     dependsOn(tasks.named("npmInstall"))
     npmCommand.set(listOf("run", "build"))
     inputs.dir("src")
     inputs.file("package.json")
     inputs.file("vite.config.ts")
     outputs.dir(layout.projectDirectory.dir("dist"))
+}
+
+val test = tasks.register<NpmTask>("test") {
+    dependsOn(tasks.named("npmInstall"))
+    npmCommand.set(listOf("run", "test"))
+    inputs.dir("src")
+    inputs.file("package.json")
+    inputs.file("tsconfig.json")
+    inputs.file("vite.config.ts")
+    outputs.upToDateWhen { false }
+}
+
+tasks.named("check") {
+    dependsOn(test)
 }

--- a/buildSrc/src/main/kotlin/beat-the-machine.publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/beat-the-machine.publishing-conventions.gradle.kts
@@ -16,7 +16,7 @@ afterEvaluate {
         repositories {
             maven {
                 name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/yonatankarp/kotlin-spring-boot-template")
+                url = uri("https://maven.pkg.github.com/yonatankarp/beat-the-machine-ddd")
                 credentials {
                     username = (project.findProperty("gpr.user") as String?) ?: System.getenv("GITHUB_ACTOR")
                     password = (project.findProperty("gpr.key") as String?) ?: System.getenv("GITHUB_TOKEN")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
-
 # testBalloon: nested IntelliJ test tree without the fully-qualified suite class prefix
 testBalloon.reportingMode=GradleIntellijIdeaWithNesting
+
+group=com.yonatankarp
+version=0.1.0-SNAPSHOT

--- a/testballoon-gwt/src/main/kotlin/com/yonatankarp/testballoon/gwt/GivenWhenThen.kt
+++ b/testballoon-gwt/src/main/kotlin/com/yonatankarp/testballoon/gwt/GivenWhenThen.kt
@@ -4,11 +4,20 @@ import de.infix.testBalloon.framework.core.Test
 import de.infix.testBalloon.framework.core.TestSuiteScope
 import kotlinx.coroutines.ThreadContextElement
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.Continuation
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 class GivenWhenThenScope(
+    internal val testSuiteScope: TestSuiteScope,
+)
+
+class WhenScope(
     internal val testSuiteScope: TestSuiteScope,
 )
 
@@ -17,7 +26,7 @@ class ThenScope(
 )
 
 class ScenarioValue<T>(
-    private val value: () -> T,
+    private val value: suspend () -> T,
 ) : ReadOnlyProperty<Any?, T> {
     override fun getValue(
         thisRef: Any?,
@@ -28,8 +37,29 @@ class ScenarioValue<T>(
                 ?: error("Scenario value '${property.name}' was read outside a then block")
 
         @Suppress("UNCHECKED_CAST")
-        return context.values.getOrPut(this) { value() } as T
+        return context.values.getOrPut(this) { runSuspend(value, ScenarioContextElement(context)) } as T
     }
+}
+
+private fun <T> runSuspend(
+    value: suspend () -> T,
+    coroutineContext: CoroutineContext,
+): T {
+    val completed = CountDownLatch(1)
+    val resultHolder = AtomicReference<Result<T>>()
+    val wrapped: suspend () -> T = { withContext(coroutineContext) { value() } }
+    wrapped.startCoroutine(
+        object : Continuation<T> {
+            override val context: CoroutineContext = EmptyCoroutineContext
+
+            override fun resumeWith(result: Result<T>) {
+                resultHolder.set(result)
+                completed.countDown()
+            }
+        },
+    )
+    completed.await()
+    return resultHolder.get().getOrThrow()
 }
 
 private class ScenarioContext {
@@ -79,15 +109,15 @@ fun GivenWhenThenScope.given(
 
 fun GivenWhenThenScope.whenever(
     description: String,
-    content: ThenScope.() -> Unit,
+    content: WhenScope.() -> Unit,
 ): Unit =
     with(testSuiteScope) {
         testSuite("when $description") {
-            ThenScope(this).content()
+            WhenScope(this).content()
         }
     }
 
-fun ThenScope.then(
+fun WhenScope.then(
     description: String,
     action: suspend Test.ExecutionScope.() -> Unit,
 ): Unit =
@@ -100,8 +130,6 @@ fun ThenScope.then(
         }
     }
 
-fun <T> GivenWhenThenScope.setup(value: () -> T): ScenarioValue<T> = ScenarioValue(value)
+fun <T> GivenWhenThenScope.setup(value: suspend () -> T): ScenarioValue<T> = ScenarioValue(value)
 
-fun <T> ThenScope.setup(value: () -> T): ScenarioValue<T> = ScenarioValue(value)
-
-fun <T> ThenScope.action(value: () -> T): ScenarioValue<T> = ScenarioValue(value)
+fun <T> WhenScope.action(value: suspend () -> T): ScenarioValue<T> = ScenarioValue(value)

--- a/testballoon-gwt/src/test/kotlin/com/yonatankarp/testballoon/gwt/GivenWhenThenDslTest.kt
+++ b/testballoon-gwt/src/test/kotlin/com/yonatankarp/testballoon/gwt/GivenWhenThenDslTest.kt
@@ -2,12 +2,13 @@ package com.yonatankarp.testballoon.gwt
 
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
 
 val GivenWhenThenDslSuite by testSuite {
-    given("setup") {
+    given("a setup value") {
         val events by setup { mutableListOf("given") }
 
-        whenever("action") {
+        whenever("an action is declared in the when scope") {
             val result by action {
                 events += "when"
                 events
@@ -21,6 +22,25 @@ val GivenWhenThenDslSuite by testSuite {
             then("second assertion sees only its own setup") {
                 result += "second then"
                 result shouldBe listOf("given", "when", "second then")
+            }
+        }
+    }
+
+    given("a suspend setup value") {
+        val initial by setup {
+            delay(1)
+            "given"
+        }
+
+        whenever("a suspend action is declared in the when scope") {
+            val result by action {
+                val base = initial
+                delay(1)
+                "$base then when"
+            }
+
+            then("the assertion can read the suspend action result") {
+                result shouldBe "given then when"
             }
         }
     }


### PR DESCRIPTION
## Summary

- Tightens the reusable GWT DSL so setup belongs to `given`, actions belong to `whenever`, and `then` blocks remain assertions.
- Hardens image generation output handling by validating provider-returned URLs, requiring image content types, adding WebClient timeouts, and preserving coroutine cancellation.
- Fixes SQLite challenge persistence edge cases for pipe-containing guesses and unknown picture statuses.
- Wires frontend Vitest into Gradle `test`, and updates dependency/CI publishing hygiene.

## Validation

- `./gradlew test`
- `./gradlew --init-script gradle/spotless.init.gradle.kts spotlessCheck`

## Notes

Remaining larger architecture follow-ups include application read models instead of returning aggregates, moving picture orchestration out of adapters, and revisiting domain picture/version modeling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable, safer image URL access control for URL-based images
* **Bug Fixes**
  * Improved image fetching with connection/request timeouts and enforced image content-type validation
  * Ensured coroutine cancellations during image processing propagate correctly
  * Improved persistence handling for guesses and picture status (including explicit pending handling)
* **Tests**
  * Expanded image URL safety/content-type/cancellation coverage
  * Added/strengthened SQLite persistence backward-compatibility and invalid-status handling
  * Updated test suites to use coroutine-capable DSL patterns
* **Chores**
  * Enabled React frontend automated npm testing in CI/build and added Dependabot daily updates; adjusted CI permissions and publishing/build settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->